### PR TITLE
[feat] add license metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,24 @@ Golang 20 is required. From there, follow the `justfile` or run `just prod` to s
 
 ```bash
 Usage of ./build/slurm_exporter:
+  -slurm.collect-licenses
+        Collect license info from slurm
+  -slurm.lic-cli string
+        squeue cli override
   -slurm.poll-limit float
         throttle for slurmctld (default: 10s)
   -slurm.sinfo-cli string
-         (default "sinfo cli override")
+        sinfo cli override
   -slurm.squeue-cli string
-         (default "squeue cli override")
+        squeue cli override
   -trace.enabled
         Set up Post endpoint for collecting traces
   -trace.path string
-        POST path to upload job proc info (default "/trace")
+        POST path to upload job proc info
   -trace.rate uint
-        number of seconds proc info should stay in memory before being marked as stale
+        number of seconds proc info should stay in memory before being marked as stale (default 10)
   -web.listen-address string
-        Address to listen on for telemetry (default: 9092)
+        Address to listen on for telemetry "(default: :9092)"
   -web.log-level string
         Log level: info, debug, error, warning
   -web.telemetry-path string

--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ $ curl localhost:8092/metrics | grep "# HELP"
 
 ### Exporter Env Var Docs
 Env vars can be sepcified in a `.env` file, while using the `just`
-| Var        | Default Value | Purpose                                                                     |
-|------------|---------------|-----------------------------------------------------------------------------|
-| POLL_LIMIT | 1             | # of seconds to wait before polling slurmctl again (client-side throtting)  |
-| LOGLEVEL   | info          | Log Level: debug, info, warn, error                                         |
+| Var           | Default Value | Purpose                                                                     |
+|---------------|---------------|-----------------------------------------------------------------------------|
+| POLL_LIMIT    | 1             | # of seconds to wait before polling slurmctl again (client-side throtting)  |
+| LOGLEVEL      | info          | Log Level: debug, info, warn, error                                         |
+| CLI_TIMEOUT   | 10.           | # seconds before the exporter terminates command.                           |
 
 
 ### Future work

--- a/fixtures/license_out.json
+++ b/fixtures/license_out.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "plugins": {
+      "data_parser": "data_parser/v0.0.39",
+      "accounting_storage": "accounting_storage/slurmdbd"
+    },
+    "command": [
+      "show",
+      "lic"
+    ],
+    "Slurm": {
+      "version": {
+        "major": 23,
+        "micro": 4,
+        "minor": 2
+      },
+      "release": "23.02.4"
+    }
+  },
+  "licenses": [{
+    "LicenseName": "AscentLintBase",
+    "Total": 7,
+    "Used": 0,
+    "Free": 7,
+    "Remote": false,
+    "Reserved": 0,
+    "LastConsumed": 0,
+    "LastDeficit": 0,
+    "LastUpdate": 0
+  }],
+  "warnings": [],
+  "errors": []
+}

--- a/fixtures/license_out.json.license
+++ b/fixtures/license_out.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0

--- a/jobs.go
+++ b/jobs.go
@@ -173,8 +173,8 @@ func (jc *JobsController) Collect(ch chan<- prometheus.Metric) {
 	}()
 	squeue, err := jc.fetcher.Fetch()
 	if err != nil {
-		slog.Error(fmt.Sprintf("fetch error %q", err))
 		jc.jobScrapeError.Inc()
+		slog.Error(fmt.Sprintf("fetch error %q", err))
 		return
 	}
 	jobMetrics, err := parseJobMetrics(squeue)

--- a/jobs.go
+++ b/jobs.go
@@ -174,7 +174,7 @@ func (jc *JobsController) Collect(ch chan<- prometheus.Metric) {
 	squeue, err := jc.fetcher.Fetch()
 	if err != nil {
 		jc.jobScrapeError.Inc()
-		slog.Error(fmt.Sprintf("fetch error %q", err))
+		slog.Error(fmt.Sprintf("job fetch error %q", err))
 		return
 	}
 	jobMetrics, err := parseJobMetrics(squeue)

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -79,7 +79,7 @@ func TestJobCollect(t *testing.T) {
 		t.Log(metric.Desc().String())
 		jobMetrics = append(jobMetrics, metric)
 	}
-	assert.Positive(len(jobMetrics))
+	assert.NotEmpty(jobMetrics)
 
 }
 

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -110,5 +110,5 @@ func TestJobDescribe(t *testing.T) {
 	for desc, ok := <-ch; ok; desc, ok = <-ch {
 		descs = append(descs, desc)
 	}
-	assert.Positive(len(descs))
+	assert.NotEmpty(descs)
 }

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ devel: build
   -slurm.lic-cli "cat fixtures/license_out.json"
 
 prod: build
-  {{build_dir}}/slurm_exporter -trace.enabled
+  {{build_dir}}/slurm_exporter -trace.enabled -slurm.collect-licenses
 
 test:
   source venv/bin/activate && go test -coverprofile {{coverage}}.out

--- a/justfile
+++ b/justfile
@@ -26,7 +26,12 @@ build:
   go build -o {{build_dir}}/slurm_exporter .
 
 devel: build
-  {{build_dir}}/slurm_exporter -trace.enabled -slurm.squeue-cli "cat fixtures/squeue_out.json" -slurm.sinfo-cli "cat fixtures/sinfo_out.json"
+  {{build_dir}}/slurm_exporter \
+  -trace.enabled \
+  -slurm.squeue-cli "cat fixtures/squeue_out.json" \
+  -slurm.sinfo-cli "cat fixtures/sinfo_out.json" \
+  -slurm.collect-licenses \
+  -slurm.lic-cli "cat fixtures/license_out.json"
 
 prod: build
   {{build_dir}}/slurm_exporter -trace.enabled

--- a/license.go
+++ b/license.go
@@ -94,9 +94,17 @@ func (lc *LicCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, lic := range licMetrics {
-		ch <- prometheus.MustNewConstMetric(lc.licTotal, prometheus.GaugeValue, float64(lic.Total), lic.LicenseName)
-		ch <- prometheus.MustNewConstMetric(lc.licFree, prometheus.GaugeValue, float64(lic.Free), lic.LicenseName)
-		ch <- prometheus.MustNewConstMetric(lc.licUsed, prometheus.GaugeValue, float64(lic.Used), lic.LicenseName)
-		ch <- prometheus.MustNewConstMetric(lc.licReserved, prometheus.GaugeValue, float64(lic.Reserved), lic.LicenseName)
+		if lic.Total > 0 {
+			ch <- prometheus.MustNewConstMetric(lc.licTotal, prometheus.GaugeValue, float64(lic.Total), lic.LicenseName)
+		}
+		if lic.Free > 0 {
+			ch <- prometheus.MustNewConstMetric(lc.licFree, prometheus.GaugeValue, float64(lic.Free), lic.LicenseName)
+		}
+		if lic.Used > 0 {
+			ch <- prometheus.MustNewConstMetric(lc.licUsed, prometheus.GaugeValue, float64(lic.Used), lic.LicenseName)
+		}
+		if lic.Reserved > 0 {
+			ch <- prometheus.MustNewConstMetric(lc.licReserved, prometheus.GaugeValue, float64(lic.Reserved), lic.LicenseName)
+		}
 	}
 }

--- a/license.go
+++ b/license.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2023 Rivos Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/slog"
+)
+
+type LicenseMetric struct {
+	LicenseName string `json:"LicenseName"`
+	Total       int    `json:"Total"`
+	Used        int    `json:"Used"`
+	Free        int    `json:"Free"`
+	Remote      bool   `json:"Remote"`
+	Reserved    int    `json:"Reserved"`
+}
+
+type ScontrolLicResponse struct {
+	Meta struct {
+		SlurmVersion struct {
+			Version struct {
+				Major int `json:"major"`
+				Micro int `json:"micro"`
+				Minor int `json:"minor"`
+			} `json:"version"`
+			Release string `json:"release"`
+		} `json:"Slurm"`
+	} `json:"meta"`
+	Licenses []LicenseMetric `json:"licenses"`
+}
+
+func parseLicenseMetrics(licList []byte) ([]LicenseMetric, error) {
+	lic := new(ScontrolLicResponse)
+	if err := json.Unmarshal(licList, lic); err != nil {
+		slog.Error(fmt.Sprintf("Unmarshaling license metrics %q", err))
+		return nil, err
+	}
+	return lic.Licenses, nil
+}
+
+type LicCollector struct {
+	fetcher        SlurmFetcher
+	licTotal       *prometheus.Desc
+	licUsed        *prometheus.Desc
+	licFree        *prometheus.Desc
+	licReserved    *prometheus.Desc
+	licScrapeError prometheus.Counter
+}
+
+func NewLicCollector(config *Config) *LicCollector {
+	cliOpts := config.cliOpts
+	fetcher := NewCliFetcher(cliOpts.lic...)
+	fetcher.cache = NewAtomicThrottledCache(config.pollLimit)
+	return &LicCollector{
+		fetcher:     fetcher,
+		licTotal:    prometheus.NewDesc("slurm_lic_total", "slurm license total", []string{"name"}, nil),
+		licUsed:     prometheus.NewDesc("slurm_lic_used", "slurm license used", []string{"name"}, nil),
+		licFree:     prometheus.NewDesc("slurm_lic_free", "slurm license free", []string{"name"}, nil),
+		licReserved: prometheus.NewDesc("slurm_lic_reserved", "slurm license reserved", []string{"name"}, nil),
+		licScrapeError: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "slurm_lic_scrape_error",
+			Help: "slurm license scrape error",
+		}),
+	}
+}
+
+func (lc *LicCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- lc.licTotal
+	ch <- lc.licUsed
+	ch <- lc.licFree
+	ch <- lc.licReserved
+	ch <- lc.licScrapeError.Desc()
+}
+
+func (lc *LicCollector) Collect(ch chan<- prometheus.Metric) {
+	defer func() {
+		ch <- lc.licScrapeError
+	}()
+	licBytes, err := lc.fetcher.Fetch()
+	if err != nil {
+		slog.Error(fmt.Sprintf("fetch error %q", err))
+		lc.licScrapeError.Inc()
+		return
+	}
+	licMetrics, err := parseLicenseMetrics(licBytes)
+	if err != nil {
+		lc.licScrapeError.Inc()
+		slog.Error(fmt.Sprintf("lic parse error %q", err))
+		return
+	}
+	for _, lic := range licMetrics {
+		ch <- prometheus.MustNewConstMetric(lc.licTotal, prometheus.GaugeValue, float64(lic.Total), lic.LicenseName)
+		ch <- prometheus.MustNewConstMetric(lc.licFree, prometheus.GaugeValue, float64(lic.Free), lic.LicenseName)
+		ch <- prometheus.MustNewConstMetric(lc.licUsed, prometheus.GaugeValue, float64(lic.Used), lic.LicenseName)
+		ch <- prometheus.MustNewConstMetric(lc.licReserved, prometheus.GaugeValue, float64(lic.Reserved), lic.LicenseName)
+	}
+}

--- a/license_test.go
+++ b/license_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2023 Rivos Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var MockLicFetcher = &MockFetcher{fixture: "fixtures/license_out.json"}
+
+func TestParseLicMetrics(t *testing.T) {
+	assert := assert.New(t)
+	fetcher := MockFetcher{fixture: "fixtures/license_out.json"}
+	data, err := fetcher.Fetch()
+	assert.Nil(err)
+	lics, err := parseLicenseMetrics(data)
+	assert.Nil(err)
+	t.Logf("lics %v", lics)
+	assert.Equal(1, len(lics))
+}
+
+func TestNewLicController(t *testing.T) {
+	assert := assert.New(t)
+	config := Config{
+		pollLimit: 10,
+		cliOpts: &CliOpts{
+			licEnabled: true,
+		},
+	}
+	lc := NewLicCollector(&config)
+	assert.NotNil(lc)
+}
+
+func TestLicCollect(t *testing.T) {
+	assert := assert.New(t)
+	config := Config{
+		pollLimit: 10,
+		cliOpts: &CliOpts{
+			licEnabled: true,
+		},
+	}
+	lc := NewLicCollector(&config)
+	lc.fetcher = MockLicFetcher
+	lcChan := make(chan prometheus.Metric)
+	go func() {
+		lc.Collect(lcChan)
+		close(lcChan)
+	}()
+	licMetrics := make([]prometheus.Metric, 0)
+	for metric, ok := <-lcChan; ok; metric, ok = <-lcChan {
+		t.Log(metric.Desc().String())
+		licMetrics = append(licMetrics, metric)
+	}
+	assert.NotEmpty(licMetrics)
+}
+
+func TestLicDescribe(t *testing.T) {
+	assert := assert.New(t)
+	config := Config{
+		pollLimit: 10,
+		cliOpts: &CliOpts{
+			licEnabled: true,
+		},
+	}
+	lc := NewLicCollector(&config)
+	lc.fetcher = MockLicFetcher
+	lcChan := make(chan *prometheus.Desc)
+	go func() {
+		lc.Describe(lcChan)
+		close(lcChan)
+	}()
+	licMetrics := make([]*prometheus.Desc, 0)
+	for desc, ok := <-lcChan; ok; desc, ok = <-lcChan {
+		t.Log(desc.String())
+		licMetrics = append(licMetrics, desc)
+	}
+	assert.NotEmpty(licMetrics)
+}

--- a/license_test.go
+++ b/license_test.go
@@ -58,6 +58,30 @@ func TestLicCollect(t *testing.T) {
 	assert.NotEmpty(licMetrics)
 }
 
+func TestLicCollect_ColectionE(t *testing.T) {
+	assert := assert.New(t)
+	config := Config{
+		pollLimit: 10,
+		cliOpts: &CliOpts{
+			licEnabled: true,
+		},
+	}
+	lc := NewLicCollector(&config)
+	lc.fetcher = new(MockFetchErrored)
+	lcChan := make(chan prometheus.Metric)
+	go func() {
+		lc.Collect(lcChan)
+		close(lcChan)
+	}()
+	licMetrics := make([]prometheus.Metric, 0)
+	for metric, ok := <-lcChan; ok; metric, ok = <-lcChan {
+		t.Log(metric.Desc().String())
+		licMetrics = append(licMetrics, metric)
+	}
+
+	assert.Equal(1, len(licMetrics))
+}
+
 func TestLicDescribe(t *testing.T) {
 	assert := assert.New(t)
 	config := Config{

--- a/main_test.go
+++ b/main_test.go
@@ -54,6 +54,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal([]string{"sinfo", "--json"}, config.cliOpts.sinfo)
 	assert.Equal([]string{"squeue", "--json"}, config.cliOpts.squeue)
+	assert.Equal([]string{"scontrol", "show", "lic", "--json"}, config.cliOpts.lic)
 	assert.Equal(uint64(10), config.traceConf.rate)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,7 +21,7 @@ func TestMain(m *testing.M) {
 	opts := slog.HandlerOptions{
 		Level: slog.LevelError,
 	}
-	textHandler := slog.NewTextHandler(os.Stdout, &opts)
+	textHandler := slog.NewTextHandler(io.Discard, &opts)
 	slog.SetDefault(slog.New(textHandler))
 	code := m.Run()
 	os.Exit(code)

--- a/nodes.go
+++ b/nodes.go
@@ -199,7 +199,7 @@ func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
 	}()
 	sinfo, err := nc.fetcher.Fetch()
 	if err != nil {
-		slog.Error("Failed to fetch from cli: " + err.Error())
+		slog.Error("node fetch error" + err.Error())
 		nc.nodeScrapeErrors.Inc()
 		return
 	}

--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -101,9 +102,16 @@ func (cf *CliFetcher) captureCli() ([]byte, error) {
 }
 
 func NewCliFetcher(args ...string) *CliFetcher {
+	var limit float64 = 10
+	var err error
+	if tm, ok := os.LookupEnv("CLI_TIMEOUT"); ok {
+		if limit, err = strconv.ParseFloat(tm, 64); err != nil {
+			slog.Error("`CLI_TIMEOUT` env var parse error parse error")
+		}
+	}
 	return &CliFetcher{
 		args:    args,
-		timeout: 10 * time.Second,
+		timeout: time.Duration(limit) * time.Second,
 		cache:   NewAtomicThrottledCache(1),
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -106,7 +106,7 @@ func NewCliFetcher(args ...string) *CliFetcher {
 	var err error
 	if tm, ok := os.LookupEnv("CLI_TIMEOUT"); ok {
 		if limit, err = strconv.ParseFloat(tm, 64); err != nil {
-			slog.Error("`CLI_TIMEOUT` env var parse error parse error")
+			slog.Error("`CLI_TIMEOUT` env var parse error")
 		}
 	}
 	return &CliFetcher{

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -42,6 +43,12 @@ type MockFetchTriggered struct {
 func (f *MockFetchTriggered) Fetch() ([]byte, error) {
 	f.called = true
 	return f.msg, nil
+}
+
+type MockFetchErrored struct{}
+
+func (f *MockFetchErrored) Fetch() ([]byte, error) {
+	return nil, errors.New("mock fetch error")
 }
 
 func TestCliFetcher(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -61,7 +61,7 @@ func TestCliFetcher(t *testing.T) {
 
 func TestCliFetcher_Timeout(t *testing.T) {
 	assert := assert.New(t)
-	cliFetcher := NewCliFetcher("ls")
+	cliFetcher := NewCliFetcher("sleep", "100")
 	cliFetcher.timeout = 0
 	data, err := cliFetcher.Fetch()
 	assert.EqualError(err, "signal: killed")


### PR DESCRIPTION
Feature to add slurm license metrics to the exporter. Something interesting we can do here is add is correlate with pending job dependencies. First, we can get MVP of this out and iterate later though