### PR TITLE
[util] export fetcher duration

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -154,11 +154,9 @@ func MemToFloat(mem string) (float64, error) {
 	re := regexp.MustCompile(`^(?P<num>([0-9]*[.])?[0-9]+)(?P<memunit>G|M|T)$`)
 	matches := re.FindStringSubmatch(mem)
 	if len(matches) < 2 {
-		slog.Error(fmt.Sprintf("mem string %s doesn't match regex %s", mem, re))
-		return -1, nil
+		return -1, fmt.Errorf("mem string %s doesn't match regex %s", mem, re)
 	}
-
-	num, _ := strconv.ParseFloat(matches[re.SubexpIndex("num")], 64)
+	num, err := strconv.ParseFloat(matches[re.SubexpIndex("num")], 64)
 	memunit := memUnits[matches[re.SubexpIndex("memunit")]]
-	return num * float64(memunit), nil
+	return num * float64(memunit), err
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -56,7 +56,7 @@ func (f *MockFetchErrored) Fetch() ([]byte, error) {
 }
 
 func (f *MockFetchErrored) Duration() time.Duration {
-	return -1
+	return 1
 }
 
 func TestCliFetcher(t *testing.T) {
@@ -137,7 +137,11 @@ func TestAtomicThrottledCache_Stale(t *testing.T) {
 	cache.cache = []byte("cache")
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
-	info, err := cache.fetchOrThrottle(fetcher.Fetch)
+	info, err := cache.fetchOrThrottle(func() ([]byte, error) {
+		// TODO: mock the wall clk, instead of wasting time
+		time.Sleep(1 * time.Millisecond)
+		return fetcher.Fetch()
+	})
 	assert.Nil(err)
 	assert.Equal(info, fetcher.msg)
 	// assert fetch not called

--- a/utils_test.go
+++ b/utils_test.go
@@ -45,10 +45,18 @@ func (f *MockFetchTriggered) Fetch() ([]byte, error) {
 	return f.msg, nil
 }
 
+func (f *MockFetchTriggered) Duration() time.Duration {
+	return -1
+}
+
 type MockFetchErrored struct{}
 
 func (f *MockFetchErrored) Fetch() ([]byte, error) {
 	return nil, errors.New("mock fetch error")
+}
+
+func (f *MockFetchErrored) Duration() time.Duration {
+	return -1
 }
 
 func TestCliFetcher(t *testing.T) {
@@ -136,6 +144,8 @@ func TestAtomicThrottledCache_Stale(t *testing.T) {
 	assert.True(fetcher.called)
 	// assert cache populated
 	assert.Equal(cache.cache, fetcher.msg)
+	// assert duration tracked
+	assert.Positive(cache.duration)
 }
 
 func TestConvertMemToFloat(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -46,7 +46,7 @@ func (f *MockFetchTriggered) Fetch() ([]byte, error) {
 }
 
 func (f *MockFetchTriggered) Duration() time.Duration {
-	return -1
+	return 1
 }
 
 type MockFetchErrored struct{}

--- a/utils_test.go
+++ b/utils_test.go
@@ -158,3 +158,10 @@ func TestConvertMemToFloat(t *testing.T) {
 		e *= 1e+3
 	}
 }
+
+func TestConvertMemToFloat_Sad(t *testing.T) {
+	assert := assert.New(t)
+	n, err := MemToFloat("afal")
+	assert.Error(err)
+	assert.Equal(-1., n)
+}


### PR DESCRIPTION
Export fetch times. We'll only export cache misses. Otherwise duration will just self-clobber with shared fetchers