### PR TITLE
[jobs] capture all job states

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func NewConfig() (*Config, error) {
 	}
 	if cliOpts.fallback {
 		// we define a custom json format that we convert back into the openapi format
-		cliOpts.squeue = []string{"squeue", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
+		cliOpts.squeue = []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
 		cliOpts.sinfo = []string{"sinfo", "-h", "-o", `{"s": "%T", "mem": %m, "n": "%n", "l": %O, "p": "%R", "fmem": %e, "cstate": "%C", "w": %w}`}
 	}
 	fetcher := NewCliFetcher(cliOpts.squeue...)

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,7 @@ func TestNewConfig_NonDefault(t *testing.T) {
 	config, err := NewConfig()
 	t.Log(slurmCliFallback)
 	assert.Nil(err)
-	expected := []string{"squeue", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
+	expected := []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
 	assert.Equal(expected, config.cliOpts.squeue)
 }
 


### PR DESCRIPTION
squeue defaults to only capturing  pending, running, and completing jobs. We want to capture all states