### PR TITLE
[squeue] fix NONE time cli-fallback bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also install the exporter directly with `go install github.com/rivosinc/
 
 ```bash
 # example installation
-$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.0.0
+$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.0.1
 # or if you like living on the edge
 $ go install github.com/rivosinc/prometheus-slurm-exporter@latest
 # if not already added, ensure

--- a/fixtures/squeue_fallback.txt
+++ b/fixtures/squeue_fallback.txt
@@ -1,3 +1,4 @@
 {"a": "account1", "id": 26515966, "end_time": "2023-09-21T00:21:42", "state": "RUNNING", "p": "hw-h", "cpu": 1, "mem": "128G"}
 {"a": "account1", "id": 50580016, "end_time": "2023-09-21T14:31:11", "state": "RUNNING", "p": "hw-l", "cpu": 1, "mem": "62.50G"}
 {"a": "account1", "id": 51447051, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M"}
+{"a": "account1", "id": 18804, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": 24, "mem": "118G"}

--- a/jobs.go
+++ b/jobs.go
@@ -71,7 +71,8 @@ func (nat *NAbleTime) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tString); err != nil {
 		return err
 	}
-	if tString == "N/A" {
+	nullSet := map[string]struct{}{"N/A": {}, "NONE": {}}
+	if _, ok := nullSet[tString]; ok {
 		nat.Time = time.Time{}
 		return nil
 	}


### PR DESCRIPTION
slurm 22.x can emmit `NONE` null vals on cmd line. Although we don't guarantee backward compatibility, this doesn't cost us anything to support. Bugs is red-green tested off-course. We might experience this same problem for NAbleFloats, but I'll wait for someone to file a bug against that before implementing it.

resolves #26 