### PR TITLE
[trace] fix template rendering

### DIFF
--- a/templates/proc_traces.html
+++ b/templates/proc_traces.html
@@ -1,10 +1,9 @@
+<!DOCTYPE html>
 <!--
 SPDX-FileCopyrightText: 2023 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
-<!DOCTYPE html>
 <html lang="en">
     <body>
         <table>


### PR DESCRIPTION
The license comment cannot appear before the doctype