### PR TITLE
[cli-fallback] no fail-fast

### DIFF
--- a/fixtures/squeue_fallback.txt
+++ b/fixtures/squeue_fallback.txt
@@ -2,3 +2,6 @@
 {"a": "account1", "id": 50580016, "end_time": "2023-09-21T14:31:11", "state": "RUNNING", "p": "hw-l", "cpu": 1, "mem": "62.50G"}
 {"a": "account1", "id": 51447051, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M"}
 {"a": "account1", "id": 18804, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": 24, "mem": "118G"}
+# test counter inc with faulty inputs
+{"a": "account1", "id": 18805, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G"}
+{"a": "account1", "id": 18806, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G"}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 )
@@ -16,7 +17,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect

--- a/trace.go
+++ b/trace.go
@@ -137,7 +137,7 @@ func (c *TraceCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	var jobMetrics []JobMetric
 	if c.fallback {
-		jobMetrics, err = parseCliFallback(squeue)
+		jobMetrics, err = parseCliFallback(squeue, prometheus.NewCounter(prometheus.CounterOpts{}))
 	} else {
 		jobMetrics, err = parseJobMetrics(squeue)
 	}

--- a/utils.go
+++ b/utils.go
@@ -137,7 +137,20 @@ func (f *MockFetcher) Fetch() ([]byte, error) {
 	defer func(t time.Time) {
 		f.duration = time.Since(t)
 	}(time.Now())
-	return os.ReadFile(f.fixture)
+	file, err := os.ReadFile(f.fixture)
+	if err != nil {
+		return nil, err
+	}
+	// allow commenting in text files
+	sep := []byte("\n")
+	lines := bytes.Split(file, sep)
+	filtered := make([][]byte, 0)
+	for _, line := range lines {
+		if !bytes.HasPrefix(line, []byte("#")) {
+			filtered = append(filtered, line)
+		}
+	}
+	return bytes.Join(filtered, sep), nil
 }
 
 func (f *MockFetcher) Duration() time.Duration {


### PR DESCRIPTION
Parse cli fallback line by line and increment error val instead of failing at the first faulty json line