### PR TITLE
[wrapper] fix verbose option

### DIFF
--- a/wrappers/proctrac.py
+++ b/wrappers/proctrac.py
@@ -114,4 +114,4 @@ Or by passing explicit cmdline args, exp.
     else:
         for trace in wrapper.poll_info():
             resp = requests.post(args.endpoint, json=dataclasses.asdict(trace))
-            args.verbose and print(dataclasses.asdict(trace), resp.json())
+            args.verbose and print(dataclasses.asdict(trace), resp)


### PR DESCRIPTION
Post response won't have json content, thus this will fail with

```python
raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Test

Terminal 1: Setup exporter

```bash
$ just devel
```

Terminal 2: Start Process to monitor (Note: the jobid must correlate to whats in the `squeue_out.json` fixture file.

```bash
echo '#!/bin/bash' > tmp.sh && echo 'timeout 60 yes >/dev/null' >> tmp.sh
chmod +x tmp.sh
python wrappers/proctrac.py --jobid 26515966 --verbose --endpoint http://localhost:9092/trace --sample-rate 2 --cmd ./tmp.sh
{'pid': 29957, 'cpus': 99.8, 'threads': 2, 'mem': 3932160, 'read_bytes': 0, 'write_bytes': 0, 'job_id': 26515966, 'username': 'codespace', 'hostname': 'codespaces-e62702'} <Response [200]>
...
```

Terminal 3: Validate

```bash
# expect to see a single table entry
$ curl localhost:9092/trace
# should have a non zero output and roughly match the trace output from before
$ curl localhost:9092/metrics | grep slurm_proc
$ curl localhost:9092/metrics | grep slurm_job
