### PR TITLE
[node] refactor node fetcher

### DIFF
--- a/diags_test.go
+++ b/diags_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseDiagJson(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := MockFetcher{fixture: "fixtures/sdiag.json"}
-	sdiag, err := fetcher.Fetch()
+	sdiag, err := fetcher.FetchRawBytes()
 	assert.NoError(err)
 	resp, err := parseDiagMetrics(sdiag)
 	assert.NoError(err)

--- a/jobs.go
+++ b/jobs.go
@@ -192,7 +192,7 @@ func parsePartitionJobMetrics(jobs []JobMetric) map[string]*PartitionJobMetric {
 
 type JobsCollector struct {
 	// collector state
-	fetcher      SlurmFetcher
+	fetcher      SlurmByteScraper
 	fallback     bool
 	jobAllocCpus *prometheus.Desc
 	jobAllocMem  *prometheus.Desc
@@ -253,7 +253,7 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 	defer func() {
 		ch <- jc.jobScrapeError
 	}()
-	squeue, err := jc.fetcher.Fetch()
+	squeue, err := jc.fetcher.FetchRawBytes()
 	if err != nil {
 		jc.jobScrapeError.Inc()
 		slog.Error(fmt.Sprintf("job fetch error %q", err))

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -40,7 +40,7 @@ func TestNewJobsController(t *testing.T) {
 
 func TestParseJobMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.Fetch()
+	fixture, err := MockJobInfoFetcher.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)
@@ -60,7 +60,7 @@ func TestParseJobMetrics(t *testing.T) {
 func TestParseCliFallback(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := MockFetcher{fixture: "fixtures/squeue_fallback.txt"}
-	data, err := fetcher.Fetch()
+	data, err := fetcher.FetchRawBytes()
 	assert.Nil(err)
 	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"})
 	metrics, err := parseCliFallback(data, counter)
@@ -72,7 +72,7 @@ func TestParseCliFallback(t *testing.T) {
 func TestUserJobMetric(t *testing.T) {
 	// setup
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.Fetch()
+	fixture, err := MockJobInfoFetcher.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)
@@ -137,7 +137,7 @@ func TestJobCollect_Fallback(t *testing.T) {
 
 func TestParsePartitionJobMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.Fetch()
+	fixture, err := MockJobInfoFetcher.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)

--- a/license.go
+++ b/license.go
@@ -44,7 +44,7 @@ func parseLicenseMetrics(licList []byte) ([]LicenseMetric, error) {
 }
 
 type LicCollector struct {
-	fetcher        SlurmFetcher
+	fetcher        SlurmByteScraper
 	licTotal       *prometheus.Desc
 	licUsed        *prometheus.Desc
 	licFree        *prometheus.Desc
@@ -81,7 +81,7 @@ func (lc *LicCollector) Collect(ch chan<- prometheus.Metric) {
 	defer func() {
 		ch <- lc.licScrapeError
 	}()
-	licBytes, err := lc.fetcher.Fetch()
+	licBytes, err := lc.fetcher.FetchRawBytes()
 	if err != nil {
 		slog.Error(fmt.Sprintf("fetch error %q", err))
 		lc.licScrapeError.Inc()

--- a/license_test.go
+++ b/license_test.go
@@ -15,7 +15,7 @@ var MockLicFetcher = &MockFetcher{fixture: "fixtures/license_out.json"}
 func TestParseLicMetrics(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := MockFetcher{fixture: "fixtures/license_out.json"}
-	data, err := fetcher.Fetch()
+	data, err := fetcher.FetchRawBytes()
 	assert.Nil(err)
 	lics, err := parseLicenseMetrics(data)
 	assert.Nil(err)

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ type TraceConfig struct {
 	enabled       bool
 	path          string
 	rate          uint64
-	sharedFetcher SlurmFetcher
+	sharedFetcher SlurmByteScraper
 }
 
 type Config struct {
@@ -145,7 +145,7 @@ func NewConfig() (*Config, error) {
 	return config, nil
 }
 
-func (c *Config) SetFetcher(fetcher SlurmFetcher) {
+func (c *Config) SetFetcher(fetcher SlurmByteScraper) {
 	c.traceConf.sharedFetcher = fetcher
 }
 

--- a/nodes.go
+++ b/nodes.go
@@ -232,7 +232,7 @@ func fetchNodeTotalMemMetrics(nodes []NodeMetric) *MemSummaryMetric {
 
 type NodesCollector struct {
 	// collector state
-	fetcher  SlurmFetcher
+	fetcher  SlurmByteScraper
 	fallback bool
 	// partition summary metrics
 	partitionCpus        *prometheus.Desc
@@ -316,7 +316,7 @@ func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
 	defer func() {
 		ch <- nc.nodeScrapeErrors
 	}()
-	sinfo, err := nc.fetcher.Fetch()
+	sinfo, err := nc.fetcher.FetchRawBytes()
 	if err != nil {
 		slog.Error("node fetch error" + err.Error())
 		nc.nodeScrapeErrors.Inc()

--- a/nodes.go
+++ b/nodes.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/slices"
@@ -46,10 +47,19 @@ type sinfoResponse struct {
 	Nodes  []NodeMetric `json:"nodes"`
 }
 
-func parseNodeMetrics(jsonNodeList []byte) ([]NodeMetric, error) {
-	squeue := sinfoResponse{}
-	err := json.Unmarshal(jsonNodeList, &squeue)
+type CliJsonMetricFetcher struct {
+	fetcher      SlurmByteScraper
+	errorCounter prometheus.Counter
+	duration     time.Duration
+}
+
+func (cmf *CliJsonMetricFetcher) FetchMetrics() ([]NodeMetric, error) {
+	squeue := new(sinfoResponse)
+	cliJson, err := cmf.fetcher.FetchRawBytes()
 	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(cliJson, squeue); err != nil {
 		slog.Error("Unmarshaling node metrics %q", err)
 		return nil, err
 	}
@@ -57,9 +67,18 @@ func parseNodeMetrics(jsonNodeList []byte) ([]NodeMetric, error) {
 		for _, e := range squeue.Errors {
 			slog.Error("Api error response %q", e)
 		}
+		cmf.errorCounter.Add(float64(len(squeue.Errors)))
 		return nil, errors.New(squeue.Errors[0])
 	}
 	return squeue.Nodes, nil
+}
+
+func (cmf *CliJsonMetricFetcher) ScrapeError() prometheus.Counter {
+	return cmf.errorCounter
+}
+
+func (cmf *CliJsonMetricFetcher) ScrapeDuration() time.Duration {
+	return cmf.fetcher.Duration()
 }
 
 type NAbleFloat float64
@@ -81,7 +100,18 @@ func (naf *NAbleFloat) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func parseNodeCliFallback(sinfo []byte) ([]NodeMetric, error) {
+type CliFallbackMetricFetcher struct {
+	fetcher      SlurmByteScraper
+	errorCounter prometheus.Counter
+	duration     time.Duration
+}
+
+func (cmf *CliFallbackMetricFetcher) FetchMetrics() ([]NodeMetric, error) {
+	sinfo, err := cmf.fetcher.FetchRawBytes()
+	if err != nil {
+		cmf.errorCounter.Inc()
+		return nil, err
+	}
 	nodeMetrics := make(map[string]*NodeMetric, 0)
 	for i, line := range bytes.Split(bytes.Trim(sinfo, "\n"), []byte("\n")) {
 		var metric struct {
@@ -102,22 +132,27 @@ func parseNodeCliFallback(sinfo []byte) ([]NodeMetric, error) {
 		metric.FreeMemory *= 1e6
 		cpuStates := strings.Split(metric.CpuState, "/")
 		if len(cpuStates) != 4 {
+			cmf.errorCounter.Inc()
 			return nil, fmt.Errorf("unexpected cpu state format. Got %s", metric.CpuState)
 		}
 		allocated, err := strconv.ParseFloat(cpuStates[0], 64)
 		if err != nil {
+			cmf.errorCounter.Inc()
 			return nil, err
 		}
 		idle, err := strconv.ParseFloat(cpuStates[1], 64)
 		if err != nil {
+			cmf.errorCounter.Inc()
 			return nil, err
 		}
 		other, err := strconv.ParseFloat(cpuStates[2], 64)
 		if err != nil {
+			cmf.errorCounter.Inc()
 			return nil, err
 		}
 		total, err := strconv.ParseFloat(cpuStates[3], 64)
 		if err != nil {
+			cmf.errorCounter.Inc()
 			return nil, err
 		}
 		_ = other
@@ -184,6 +219,14 @@ func fetchNodePartitionMetrics(nodes []NodeMetric) map[string]*PartitionMetric {
 	return partitions
 }
 
+func (cmf *CliFallbackMetricFetcher) ScrapeError() prometheus.Counter {
+	return cmf.errorCounter
+}
+
+func (cmf *CliFallbackMetricFetcher) ScrapeDuration() time.Duration {
+	return cmf.fetcher.Duration()
+}
+
 type PerStateMetric struct {
 	Cpus  float64
 	Count float64
@@ -232,8 +275,7 @@ func fetchNodeTotalMemMetrics(nodes []NodeMetric) *MemSummaryMetric {
 
 type NodesCollector struct {
 	// collector state
-	fetcher  SlurmByteScraper
-	fallback bool
+	fetcher SlurmMetricFetcher[NodeMetric]
 	// partition summary metrics
 	partitionCpus        *prometheus.Desc
 	partitionRealMemory  *prometheus.Desc
@@ -260,11 +302,18 @@ type NodesCollector struct {
 
 func NewNodeCollecter(config *Config) *NodesCollector {
 	cliOpts := config.cliOpts
-	fetcher := NewCliFetcher(cliOpts.sinfo...)
-	fetcher.cache = NewAtomicThrottledCache(config.pollLimit)
+	byteScraper := NewCliFetcher(cliOpts.sinfo...)
+	byteScraper.cache = NewAtomicThrottledCache(config.pollLimit)
+	errorCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "slurm_node_scrape_error",
+		Help: "slurm node info scrape errors",
+	})
+	fetcher := &CliJsonMetricFetcher{fetcher: byteScraper, errorCounter: errorCounter}
+	if cliOpts.fallback {
+		fetcher = &CliJsonMetricFetcher{fetcher: byteScraper, errorCounter: errorCounter}
+	}
 	return &NodesCollector{
-		fetcher:  fetcher,
-		fallback: cliOpts.fallback,
+		fetcher: fetcher,
 		// partition stats
 		partitionCpus:        prometheus.NewDesc("slurm_partition_total_cpus", "Total cpus per partition", []string{"partition"}, nil),
 		partitionRealMemory:  prometheus.NewDesc("slurm_partition_real_mem", "Real mem per partition", []string{"partition"}, nil),
@@ -286,10 +335,7 @@ func NewNodeCollecter(config *Config) *NodesCollector {
 		totalAllocMemory: prometheus.NewDesc("slurm_mem_alloc", "Total alloc mem", nil, nil),
 		// exporter stats
 		nodeScrapeDuration: prometheus.NewDesc("slurm_node_scrape_duration", fmt.Sprintf("how long the cmd %v took (ms)", cliOpts.sinfo), nil, nil),
-		nodeScrapeErrors: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "slurm_node_scrape_error",
-			Help: "slurm node info scrape errors",
-		}),
+		nodeScrapeErrors:   fetcher.ScrapeError(),
 	}
 }
 
@@ -314,23 +360,11 @@ func (nc *NodesCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
 	defer func() {
-		ch <- nc.nodeScrapeErrors
+		ch <- nc.fetcher.ScrapeError()
 	}()
-	sinfo, err := nc.fetcher.FetchRawBytes()
+	nodeMetrics, err := nc.fetcher.FetchMetrics()
+	ch <- prometheus.MustNewConstMetric(nc.nodeScrapeDuration, prometheus.GaugeValue, float64(nc.fetcher.ScrapeDuration().Milliseconds()))
 	if err != nil {
-		slog.Error("node fetch error" + err.Error())
-		nc.nodeScrapeErrors.Inc()
-		return
-	}
-	ch <- prometheus.MustNewConstMetric(nc.nodeScrapeDuration, prometheus.GaugeValue, float64(nc.fetcher.Duration().Milliseconds()))
-	var nodeMetrics []NodeMetric
-	if nc.fallback {
-		nodeMetrics, err = parseNodeCliFallback(sinfo)
-	} else {
-		nodeMetrics, err = parseNodeMetrics(sinfo)
-	}
-	if err != nil {
-		nc.nodeScrapeErrors.Inc()
 		slog.Error("Failed to parse node metrics: " + err.Error())
 		return
 	}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -16,7 +16,7 @@ import (
 var MockNodeInfoFetcher = &MockFetcher{fixture: "fixtures/sinfo_out.json"}
 
 func TestParseNodeMetrics(t *testing.T) {
-	fixture, err := MockNodeInfoFetcher.Fetch()
+	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
 	if err != nil {
 		t.Fatalf("Failed to read file with %q", err)
 	}
@@ -32,7 +32,7 @@ func TestParseNodeMetrics(t *testing.T) {
 
 func TestPartitionMetric(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.Fetch()
+	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
 	assert.NoError(err)
 	nodeMetrics, err := parseNodeMetrics(fixture)
 	assert.Nil(err)
@@ -50,7 +50,7 @@ func TestPartitionMetric(t *testing.T) {
 
 func TestNodeSummaryCpuMetric(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.Fetch()
+	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
 	assert.NoError(err)
 	nodeMetrics, err := parseNodeMetrics(fixture)
 	assert.Nil(err)
@@ -64,7 +64,7 @@ func TestNodeSummaryCpuMetric(t *testing.T) {
 
 func TestNodeSummaryMemoryMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.Fetch()
+	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
 	assert.NoError(err)
 	nodeMetrics, err := parseNodeMetrics(fixture)
 	assert.Nil(err)
@@ -115,7 +115,7 @@ func TestNodeDescribe(t *testing.T) {
 func TestParseFallbackNodeMetrics(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := &MockFetcher{fixture: "fixtures/sinfo_fallback.txt"}
-	data, err := fetcher.Fetch()
+	data, err := fetcher.FetchRawBytes()
 	assert.Nil(err)
 	metrics, err := parseNodeCliFallback(data)
 	assert.Nil(err)

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -16,25 +16,21 @@ import (
 var MockNodeInfoFetcher = &MockFetcher{fixture: "fixtures/sinfo_out.json"}
 
 func TestParseNodeMetrics(t *testing.T) {
-	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
-	if err != nil {
-		t.Fatalf("Failed to read file with %q", err)
-	}
-	metrics, err := parseNodeMetrics(fixture)
+	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	nodeMetrics, err := fetcher.FetchMetrics()
 	if err != nil {
 		t.Fatalf("Failed to parse metrics with %s", err)
 	}
-	if len(metrics) == 0 {
+	if len(nodeMetrics) == 0 {
 		t.Fatal("No metrics received")
 	}
-	t.Logf("Node metrics collected %d", len(metrics))
+	t.Logf("Node metrics collected %d", len(nodeMetrics))
 }
 
 func TestPartitionMetric(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
-	assert.NoError(err)
-	nodeMetrics, err := parseNodeMetrics(fixture)
+	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodePartitionMetrics(nodeMetrics)
 	assert.Equal(1, len(metrics))
@@ -50,9 +46,8 @@ func TestPartitionMetric(t *testing.T) {
 
 func TestNodeSummaryCpuMetric(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
-	assert.NoError(err)
-	nodeMetrics, err := parseNodeMetrics(fixture)
+	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodeTotalCpuMetrics(nodeMetrics)
 	assert.Equal(4, len(metrics.PerState))
@@ -64,9 +59,8 @@ func TestNodeSummaryCpuMetric(t *testing.T) {
 
 func TestNodeSummaryMemoryMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockNodeInfoFetcher.FetchRawBytes()
-	assert.NoError(err)
-	nodeMetrics, err := parseNodeMetrics(fixture)
+	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodeTotalMemMetrics(nodeMetrics)
 	assert.Equal(114688., metrics.AllocMemory)
@@ -80,7 +74,7 @@ func TestNodeCollector(t *testing.T) {
 	assert.Nil(err)
 	nc := NewNodeCollecter(config)
 	// cache miss, use our mock fetcher
-	nc.fetcher = MockNodeInfoFetcher
+	nc.fetcher = &CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
 	metricChan := make(chan prometheus.Metric)
 	go func() {
 		nc.Collect(metricChan)
@@ -100,7 +94,7 @@ func TestNodeDescribe(t *testing.T) {
 	config, err := NewConfig()
 	assert.Nil(err)
 	jc := NewNodeCollecter(config)
-	jc.fetcher = MockJobInfoFetcher
+	jc.fetcher = &CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
 	go func() {
 		jc.Describe(ch)
 		close(ch)
@@ -114,10 +108,9 @@ func TestNodeDescribe(t *testing.T) {
 
 func TestParseFallbackNodeMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := &MockFetcher{fixture: "fixtures/sinfo_fallback.txt"}
-	data, err := fetcher.FetchRawBytes()
-	assert.Nil(err)
-	metrics, err := parseNodeCliFallback(data)
+	byteFetcher := &MockFetcher{fixture: "fixtures/sinfo_fallback.txt"}
+	fetcher := CliFallbackMetricFetcher{fetcher: byteFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	metrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	assert.NotEmpty(metrics)
 	cs25idx := slices.IndexFunc(metrics, func(nm NodeMetric) bool { return nm.Hostname == "cs25" })

--- a/trace.go
+++ b/trace.go
@@ -86,7 +86,7 @@ func (m *AtomicProcFetcher) Fetch() map[int64]*TraceInfo {
 
 type TraceCollector struct {
 	ProcessFetcher *AtomicProcFetcher
-	squeueFetcher  SlurmFetcher
+	squeueFetcher  SlurmByteScraper
 	fallback       bool
 	// actual proc monitoring
 	jobAllocMem  *prometheus.Desc
@@ -130,7 +130,7 @@ func (c *TraceCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *TraceCollector) Collect(ch chan<- prometheus.Metric) {
 	procs := c.ProcessFetcher.Fetch()
-	squeue, err := c.squeueFetcher.Fetch()
+	squeue, err := c.squeueFetcher.FetchRawBytes()
 	if err != nil {
 		slog.Debug(fmt.Sprintf("squeue fetch failed with %q", err))
 		return

--- a/trace_test.go
+++ b/trace_test.go
@@ -184,7 +184,7 @@ func TestPython3Wrapper(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := NewCliFetcher("python3", "wrappers/proctrac.py", "--cmd", "sleep", "100", "--jobid=10", "--validate")
 	t.Logf("cmd: %+v", fetcher.args)
-	wrapperOut, err := fetcher.Fetch()
+	wrapperOut, err := fetcher.FetchRawBytes()
 	assert.Nil(err)
 	var info TraceInfo
 	json.Unmarshal(wrapperOut, &info)

--- a/utils.go
+++ b/utils.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/slog"
 )
 
@@ -33,7 +34,7 @@ type SlurmByteScraper interface {
 type SlurmMetricFetcher[M SlurmPrimitiveMetric] interface {
 	FetchMetrics() ([]M, error)
 	ScrapeDuration() time.Duration
-	ScrapeError() int64
+	ScrapeError() prometheus.Counter
 }
 
 type AtomicThrottledCache struct {

--- a/utils_test.go
+++ b/utils_test.go
@@ -51,7 +51,7 @@ func (f *MockFetchTriggered) Duration() time.Duration {
 
 type MockFetchErrored struct{}
 
-func (f *MockFetchErrored) Fetch() ([]byte, error) {
+func (f *MockFetchErrored) FetchRawBytes() ([]byte, error) {
 	return nil, errors.New("mock fetch error")
 }
 
@@ -62,7 +62,7 @@ func (f *MockFetchErrored) Duration() time.Duration {
 func TestCliFetcher(t *testing.T) {
 	assert := assert.New(t)
 	cliFetcher := NewCliFetcher("ls")
-	data, err := cliFetcher.Fetch()
+	data, err := cliFetcher.FetchRawBytes()
 	assert.Nil(err)
 	assert.NotNil(data)
 }
@@ -71,7 +71,7 @@ func TestCliFetcher_Timeout(t *testing.T) {
 	assert := assert.New(t)
 	cliFetcher := NewCliFetcher("sleep", "100")
 	cliFetcher.timeout = 0
-	data, err := cliFetcher.Fetch()
+	data, err := cliFetcher.FetchRawBytes()
 	assert.EqualError(err, "signal: killed")
 	assert.Nil(data)
 }
@@ -79,7 +79,7 @@ func TestCliFetcher_Timeout(t *testing.T) {
 func TestCliFetcher_EmptyArgs(t *testing.T) {
 	assert := assert.New(t)
 	cliFetcher := NewCliFetcher()
-	data, err := cliFetcher.Fetch()
+	data, err := cliFetcher.FetchRawBytes()
 	assert.EqualError(err, "need at least 1 args")
 	assert.Nil(data)
 }
@@ -87,7 +87,7 @@ func TestCliFetcher_EmptyArgs(t *testing.T) {
 func TestCliFetcher_ExitCodeCmd(t *testing.T) {
 	assert := assert.New(t)
 	cliFetcher := NewCliFetcher("ls", generateRandString(64))
-	data, err := cliFetcher.Fetch()
+	data, err := cliFetcher.FetchRawBytes()
 	assert.NotNil(err)
 	assert.Nil(data)
 }
@@ -97,7 +97,7 @@ func TestCliFetcher_StdErr(t *testing.T) {
 	// the rare case where stderr is written but exit code is still 0
 	cmd := `echo -e "error" 1>&2`
 	cliFetcher := NewCliFetcher("/bin/bash", "-c", cmd)
-	data, err := cliFetcher.Fetch()
+	data, err := cliFetcher.FetchRawBytes()
 	assert.NotNil(err)
 	assert.Nil(data)
 }


### PR DESCRIPTION
Refactor so we can implement the `SlurmMetricFetcher` in our cslurm module without having to marshal bytes. 