### PR TITLE
[util] generic atomic cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,3 @@ RUN cargo install just
 # load project and cluster configs
 ADD . .
 ARG USER=$USER
-RUN mv tmp_sconfs/slurm* /etc/slurm && mv tmp_sconfs/munge.key /etc/munge && \
-    sed -i '/SlurmUser=/d' /etc/slurm/slurm.conf

--- a/diags.go
+++ b/diags.go
@@ -78,7 +78,7 @@ type DiagnosticsCollector struct {
 func NewDiagsCollector(config *Config) *DiagnosticsCollector {
 	cliOpts := config.cliOpts
 	return &DiagnosticsCollector{
-		fetcher:                NewCliFetcher(config.cliOpts.sdiag...),
+		fetcher:                NewCliScraper(config.cliOpts.sdiag...),
 		slurmUserRpcCount:      prometheus.NewDesc("slurm_rpc_user_count", "slurm rpc count per user", []string{"user"}, nil),
 		slurmUserRpcTotalTime:  prometheus.NewDesc("slurm_rpc_user_total_time", "slurm rpc avg time per user", []string{"user"}, nil),
 		slurmTypeRpcCount:      prometheus.NewDesc("slurm_rpc_msg_type_count", "slurm rpc count per message type", []string{"type"}, nil),

--- a/diags_test.go
+++ b/diags_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestParseDiagJson(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := MockFetcher{fixture: "fixtures/sdiag.json"}
+	fetcher := MockScraper{fixture: "fixtures/sdiag.json"}
 	sdiag, err := fetcher.FetchRawBytes()
 	assert.NoError(err)
 	resp, err := parseDiagMetrics(sdiag)
@@ -26,7 +26,7 @@ func TestDiagCollect(t *testing.T) {
 	config, err := NewConfig()
 	assert.NoError(err)
 	dc := NewDiagsCollector(config)
-	dc.fetcher = &MockFetcher{fixture: "fixtures/sdiag.json"}
+	dc.fetcher = &MockScraper{fixture: "fixtures/sdiag.json"}
 	metricChan := make(chan prometheus.Metric)
 	go func() {
 		dc.Collect(metricChan)
@@ -46,7 +46,7 @@ func TestDiagDescribe(t *testing.T) {
 	config, err := NewConfig()
 	assert.Nil(err)
 	dc := NewDiagsCollector(config)
-	dc.fetcher = &MockFetcher{fixture: "fixtures/sdiag.json"}
+	dc.fetcher = &MockScraper{fixture: "fixtures/sdiag.json"}
 	go func() {
 		dc.Describe(ch)
 		close(ch)

--- a/jobs.go
+++ b/jobs.go
@@ -300,7 +300,7 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- jc.fetcher.ScrapeError()
 	}()
 	jobMetrics, err := jc.fetcher.FetchMetrics()
-	ch <- prometheus.MustNewConstMetric(jc.jobScrapeDuration, prometheus.GaugeValue, float64(jc.fetcher.ScrapeDuration().Microseconds()))
+	ch <- prometheus.MustNewConstMetric(jc.jobScrapeDuration, prometheus.GaugeValue, float64(jc.fetcher.ScrapeDuration().Milliseconds()))
 	if err != nil {
 		slog.Error("fetcher failure %q", err)
 		return

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var MockJobInfoFetcher = &MockFetcher{fixture: "fixtures/squeue_out.json"}
+var MockJobInfoScraper = &MockScraper{fixture: "fixtures/squeue_out.json"}
 
 func CollectCounterValue(counter prometheus.Counter) float64 {
 	metricChan := make(chan prometheus.Metric, 1)
@@ -29,7 +29,7 @@ func TestNewJobsController(t *testing.T) {
 		pollLimit: 10,
 		traceConf: &TraceConfig{
 			sharedFetcher: &JobCliFallbackFetcher{
-				scraper:    &MockFetcher{fixture: "fixtures/squeue_fallback.txt"},
+				scraper:    &MockScraper{fixture: "fixtures/squeue_fallback.txt"},
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -44,7 +44,7 @@ func TestNewJobsController(t *testing.T) {
 
 func TestParseJobMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.FetchRawBytes()
+	fixture, err := MockJobInfoScraper.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)
@@ -63,7 +63,7 @@ func TestParseJobMetrics(t *testing.T) {
 
 func TestParseCliFallback(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := MockFetcher{fixture: "fixtures/squeue_fallback.txt"}
+	fetcher := MockScraper{fixture: "fixtures/squeue_fallback.txt"}
 	data, err := fetcher.FetchRawBytes()
 	assert.Nil(err)
 	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"})
@@ -76,7 +76,7 @@ func TestParseCliFallback(t *testing.T) {
 func TestUserJobMetric(t *testing.T) {
 	// setup
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.FetchRawBytes()
+	fixture, err := MockJobInfoScraper.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)
@@ -94,7 +94,7 @@ func TestJobCollect(t *testing.T) {
 		pollLimit: 10,
 		traceConf: &TraceConfig{
 			sharedFetcher: &JobJsonFetcher{
-				scraper:    &MockFetcher{fixture: "fixtures/squeue_out.json"},
+				scraper:    &MockScraper{fixture: "fixtures/squeue_out.json"},
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -122,7 +122,7 @@ func TestJobCollect_Fallback(t *testing.T) {
 		pollLimit: 10,
 		traceConf: &TraceConfig{
 			sharedFetcher: &JobCliFallbackFetcher{
-				scraper:    &MockFetcher{fixture: "fixtures/squeue_fallback.txt"},
+				scraper:    &MockScraper{fixture: "fixtures/squeue_fallback.txt"},
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -149,7 +149,7 @@ func TestJobCollect_Fallback(t *testing.T) {
 
 func TestParsePartitionJobMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fixture, err := MockJobInfoFetcher.FetchRawBytes()
+	fixture, err := MockJobInfoScraper.FetchRawBytes()
 	assert.Nil(err)
 	jms, err := parseJobMetrics(fixture)
 	assert.Nil(err)
@@ -164,7 +164,7 @@ func TestJobDescribe(t *testing.T) {
 	config, err := NewConfig()
 	assert.Nil(err)
 	config.traceConf.sharedFetcher = &JobJsonFetcher{
-		scraper:    MockJobInfoFetcher,
+		scraper:    MockJobInfoScraper,
 		cache:      NewAtomicThrottledCache[JobMetric](1),
 		errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 	}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,8 @@
 build_dir := "./build"
 coverage := "coverage"
 vpython := "venv/bin/python3"
+ld_library := "/usr/lib64/slurm"
+include_path := "/usr/lib64/include"
 
 # Implicitly source '.env' files when running commands.
 set dotenv-load
@@ -46,11 +48,11 @@ fmt:
 
 docker-ctest:
   rm -rf {{build_dir}} && mkdir -p {{build_dir}}
-  g++ cslurm.cpp -I/usr/lib64/include -L/usr/lib64/lib/slurm -lslurmfull -g -o build/cslurm
+  g++ cslurm.cpp -I{{include_path}} -L{{ld_library}} -lslurmfull -g -o build/cslurm
   # technically this should be ok to run natively...
   if ! [[ `stat /run/munge/munge.socket.2 2> /dev/null` ]]; then munged -f; fi
   LD_LIBRARY_PATH=/usr/lib64/lib/slurm/ ./build/cslurm
 
 test-all:
   if ! [[ `stat /run/munge/munge.socket.2 2> /dev/null` ]]; then munged -f; fi
-  source venv/bin/activate && CGO_CXXFLAGS="-I/usr/lib64/include" CGO_LDFLAGS="-L/usr/lib64/lib/slurm -lslurmfull" LD_LIBRARY_PATH=/usr/lib64/lib/slurm go test . ./slurmcprom
+  source venv/bin/activate && CGO_CXXFLAGS="-I{{include_path}}" CGO_LDFLAGS="-L{{ld_library}} -lslurmfull" LD_LIBRARY_PATH={{ld_library}} go test . ./slurmcprom

--- a/license.go
+++ b/license.go
@@ -80,7 +80,7 @@ type LicCollector struct {
 func NewLicCollector(config *Config) *LicCollector {
 	cliOpts := config.cliOpts
 	fetcher := &CliJsonLicMetricFetcher{
-		scraper: NewCliFetcher(cliOpts.lic...),
+		scraper: NewCliScraper(cliOpts.lic...),
 		cache:   NewAtomicThrottledCache[LicenseMetric](config.pollLimit),
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "slurm_lic_scrape_error",

--- a/license.go
+++ b/license.go
@@ -55,7 +55,7 @@ type LicCollector struct {
 func NewLicCollector(config *Config) *LicCollector {
 	cliOpts := config.cliOpts
 	fetcher := NewCliFetcher(cliOpts.lic...)
-	fetcher.cache = NewAtomicThrottledCache(config.pollLimit)
+	fetcher.cache = NewAtomicThrottledCache[byte](config.pollLimit)
 	return &LicCollector{
 		fetcher:     fetcher,
 		licTotal:    prometheus.NewDesc("slurm_lic_total", "slurm license total", []string{"name"}, nil),

--- a/license_test.go
+++ b/license_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var MockLicFetcher = &MockFetcher{fixture: "fixtures/license_out.json"}
+var MockLicFetcher = &MockScraper{fixture: "fixtures/license_out.json"}
 
 func TestNewLicController(t *testing.T) {
 	assert := assert.New(t)

--- a/main.go
+++ b/main.go
@@ -139,9 +139,6 @@ func NewConfig() (*Config, error) {
 		cliOpts.squeue = []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
 		cliOpts.sinfo = []string{"sinfo", "-h", "-o", `{"s": "%T", "mem": %m, "n": "%n", "l": "%O", "p": "%R", "fmem": "%e", "cstate": "%C", "w": %w}`}
 	}
-	fetcher := NewCliFetcher(cliOpts.squeue...)
-	fetcher.cache = NewAtomicThrottledCache[byte](config.pollLimit)
-	config.SetFetcher(fetcher)
 	return config, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func NewConfig() (*Config, error) {
 		cliOpts.lic = strings.Split(*slurmLicenseOverride, " ")
 	}
 	traceConf.sharedFetcher = &JobJsonFetcher{
-		scraper: NewCliFetcher(cliOpts.squeue...),
+		scraper: NewCliScraper(cliOpts.squeue...),
 		cache:   NewAtomicThrottledCache[JobMetric](config.pollLimit),
 		errCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "job_scrape_errors",
@@ -147,7 +147,7 @@ func NewConfig() (*Config, error) {
 		cliOpts.squeue = []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
 		cliOpts.sinfo = []string{"sinfo", "-h", "-o", `{"s": "%T", "mem": %m, "n": "%n", "l": "%O", "p": "%R", "fmem": "%e", "cstate": "%C", "w": %w}`}
 		traceConf.sharedFetcher = &JobCliFallbackFetcher{
-			scraper: NewCliFetcher(cliOpts.squeue...),
+			scraper: NewCliScraper(cliOpts.squeue...),
 			cache:   NewAtomicThrottledCache[JobMetric](config.pollLimit),
 			errCounter: prometheus.NewCounter(prometheus.CounterOpts{
 				Name: "job_scrape_errors",

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func NewConfig() (*Config, error) {
 		cliOpts.sinfo = []string{"sinfo", "-h", "-o", `{"s": "%T", "mem": %m, "n": "%n", "l": "%O", "p": "%R", "fmem": "%e", "cstate": "%C", "w": %w}`}
 	}
 	fetcher := NewCliFetcher(cliOpts.squeue...)
-	fetcher.cache = NewAtomicThrottledCache(config.pollLimit)
+	fetcher.cache = NewAtomicThrottledCache[byte](config.pollLimit)
 	config.SetFetcher(fetcher)
 	return config, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func TestPromServer(t *testing.T) {
 		traceConf: &TraceConfig{
 			enabled: false,
 			sharedFetcher: &JobJsonFetcher{
-				scraper: NewCliFetcher(cliOpts.squeue...),
+				scraper: NewCliScraper(cliOpts.squeue...),
 				cache:   NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{
 					Name: "slurm_job_scrape_error",

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slog"
 )
@@ -29,16 +30,26 @@ func TestMain(m *testing.M) {
 
 func TestPromServer(t *testing.T) {
 	assert := assert.New(t)
+	cliOpts := &CliOpts{
+		sinfo:  []string{"cat", "fixtures/sinfo_out.json"},
+		squeue: []string{"cat", "fixtures/squeue_out.json"},
+	}
+
 	config := &Config{
 		pollLimit: 10,
-		cliOpts: &CliOpts{
-			sinfo:  []string{"cat", "fixtures/sinfo_out.json"},
-			squeue: []string{"cat", "fixtures/squeue_out.json"},
+		cliOpts:   cliOpts,
+		traceConf: &TraceConfig{
+			enabled: false,
+			sharedFetcher: &JobJsonFetcher{
+				scraper: NewCliFetcher(cliOpts.squeue...),
+				cache:   NewAtomicThrottledCache[JobMetric](1),
+				errCounter: prometheus.NewCounter(prometheus.CounterOpts{
+					Name: "slurm_job_scrape_error",
+					Help: "job scrape error",
+				}),
+			},
 		},
-		traceConf: new(TraceConfig),
 	}
-	cliOpts := config.cliOpts
-	config.SetFetcher(NewCliFetcher(cliOpts.squeue...))
 	server := initPromServer(config)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/nodes.go
+++ b/nodes.go
@@ -48,14 +48,14 @@ type sinfoResponse struct {
 }
 
 type NodeJsonFetcher struct {
-	fetcher      SlurmByteScraper
+	scraper      SlurmByteScraper
 	errorCounter prometheus.Counter
 	cache        *AtomicThrottledCache[NodeMetric]
 }
 
-func (cmf *NodeJsonFetcher) FetchMetrics() ([]NodeMetric, error) {
+func (cmf *NodeJsonFetcher) fetch() ([]NodeMetric, error) {
 	squeue := new(sinfoResponse)
-	cliJson, err := cmf.fetcher.FetchRawBytes()
+	cliJson, err := cmf.scraper.FetchRawBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -73,13 +73,16 @@ func (cmf *NodeJsonFetcher) FetchMetrics() ([]NodeMetric, error) {
 	return squeue.Nodes, nil
 }
 
+func (cmf *NodeJsonFetcher) FetchMetrics() ([]NodeMetric, error) {
+	return cmf.cache.FetchOrThrottle(cmf.fetch)
+}
 
 func (cmf *NodeJsonFetcher) ScrapeError() prometheus.Counter {
 	return cmf.errorCounter
 }
 
 func (cmf *NodeJsonFetcher) ScrapeDuration() time.Duration {
-	return cmf.fetcher.Duration()
+	return cmf.scraper.Duration()
 }
 
 type NAbleFloat float64
@@ -102,13 +105,13 @@ func (naf *NAbleFloat) UnmarshalJSON(data []byte) error {
 }
 
 type NodeCliFallbackFetcher struct {
-	fetcher      SlurmByteScraper
+	scraper      SlurmByteScraper
 	errorCounter prometheus.Counter
 	cache        *AtomicThrottledCache[NodeMetric]
 }
 
-func (cmf *NodeCliFallbackFetcher) FetchMetrics() ([]NodeMetric, error) {
-	sinfo, err := cmf.fetcher.FetchRawBytes()
+func (cmf *NodeCliFallbackFetcher) fetch() ([]NodeMetric, error) {
+	sinfo, err := cmf.scraper.FetchRawBytes()
 	if err != nil {
 		cmf.errorCounter.Inc()
 		return nil, err
@@ -187,7 +190,7 @@ func (cmf *NodeCliFallbackFetcher) FetchMetrics() ([]NodeMetric, error) {
 	return values, nil
 }
 
-func (cmf *CliFallbackMetricFetcher) FetchMetrics() ([]NodeMetric, error) {
+func (cmf *NodeCliFallbackFetcher) FetchMetrics() ([]NodeMetric, error) {
 	return cmf.cache.FetchOrThrottle(cmf.fetch)
 }
 
@@ -229,7 +232,7 @@ func (cmf *NodeCliFallbackFetcher) ScrapeError() prometheus.Counter {
 }
 
 func (cmf *NodeCliFallbackFetcher) ScrapeDuration() time.Duration {
-	return cmf.fetcher.Duration()
+	return cmf.scraper.Duration()
 }
 
 type PerStateMetric struct {
@@ -314,9 +317,9 @@ func NewNodeCollecter(config *Config) *NodesCollector {
 	})
 	var fetcher SlurmMetricFetcher[NodeMetric]
 	if cliOpts.fallback {
-		fetcher = &NodeCliFallbackFetcher{fetcher: byteScraper, errorCounter: errorCounter}
+		fetcher = &NodeCliFallbackFetcher{scraper: byteScraper, errorCounter: errorCounter, cache: NewAtomicThrottledCache[NodeMetric](config.pollLimit)}
 	} else {
-		fetcher = &NodeJsonFetcher{fetcher: byteScraper, errorCounter: errorCounter}
+		fetcher = &NodeJsonFetcher{scraper: byteScraper, errorCounter: errorCounter, cache: NewAtomicThrottledCache[NodeMetric](config.pollLimit)}
 	}
 	return &NodesCollector{
 		fetcher: fetcher,

--- a/nodes.go
+++ b/nodes.go
@@ -310,7 +310,7 @@ type NodesCollector struct {
 
 func NewNodeCollecter(config *Config) *NodesCollector {
 	cliOpts := config.cliOpts
-	byteScraper := NewCliFetcher(cliOpts.sinfo...)
+	byteScraper := NewCliScraper(cliOpts.sinfo...)
 	errorCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "slurm_node_scrape_error",
 		Help: "slurm node info scrape errors",

--- a/nodes.go
+++ b/nodes.go
@@ -303,7 +303,7 @@ type NodesCollector struct {
 func NewNodeCollecter(config *Config) *NodesCollector {
 	cliOpts := config.cliOpts
 	byteScraper := NewCliFetcher(cliOpts.sinfo...)
-	byteScraper.cache = NewAtomicThrottledCache(config.pollLimit)
+	byteScraper.cache = NewAtomicThrottledCache[byte](config.pollLimit)
 	errorCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "slurm_node_scrape_error",
 		Help: "slurm node info scrape errors",

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -13,11 +13,11 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var MockNodeInfoFetcher = &MockFetcher{fixture: "fixtures/sinfo_out.json"}
+var MockNodeInfoScraper = &MockScraper{fixture: "fixtures/sinfo_out.json"}
 
 func TestParseNodeMetrics(t *testing.T) {
 	fetcher := CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -34,7 +34,7 @@ func TestParseNodeMetrics(t *testing.T) {
 func TestPartitionMetric(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -55,7 +55,7 @@ func TestPartitionMetric(t *testing.T) {
 func TestNodeSummaryCpuMetric(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -72,7 +72,7 @@ func TestNodeSummaryCpuMetric(t *testing.T) {
 func TestNodeSummaryMemoryMetrics(t *testing.T) {
 	assert := assert.New(t)
 	fetcher := CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -91,7 +91,7 @@ func TestNodeCollector(t *testing.T) {
 	nc := NewNodeCollecter(config)
 	// cache miss, use our mock fetcher
 	nc.fetcher = &CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -115,7 +115,7 @@ func TestNodeDescribe(t *testing.T) {
 	assert.Nil(err)
 	jc := NewNodeCollecter(config)
 	jc.fetcher = &CliJsonMetricFetcher{
-		fetcher:      MockNodeInfoFetcher,
+		fetcher:      MockNodeInfoScraper,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 		cache:        NewAtomicThrottledCache[NodeMetric](1),
 	}
@@ -132,7 +132,7 @@ func TestNodeDescribe(t *testing.T) {
 
 func TestParseFallbackNodeMetrics(t *testing.T) {
 	assert := assert.New(t)
-	byteFetcher := &MockFetcher{fixture: "fixtures/sinfo_fallback.txt"}
+	byteFetcher := &MockScraper{fixture: "fixtures/sinfo_fallback.txt"}
 	fetcher := CliFallbackMetricFetcher{
 		fetcher:      byteFetcher,
 		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -16,7 +16,11 @@ import (
 var MockNodeInfoFetcher = &MockFetcher{fixture: "fixtures/sinfo_out.json"}
 
 func TestParseNodeMetrics(t *testing.T) {
-	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	fetcher := CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	nodeMetrics, err := fetcher.FetchMetrics()
 	if err != nil {
 		t.Fatalf("Failed to parse metrics with %s", err)
@@ -29,7 +33,11 @@ func TestParseNodeMetrics(t *testing.T) {
 
 func TestPartitionMetric(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	fetcher := CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodePartitionMetrics(nodeMetrics)
@@ -46,7 +54,11 @@ func TestPartitionMetric(t *testing.T) {
 
 func TestNodeSummaryCpuMetric(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	fetcher := CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodeTotalCpuMetrics(nodeMetrics)
@@ -59,7 +71,11 @@ func TestNodeSummaryCpuMetric(t *testing.T) {
 
 func TestNodeSummaryMemoryMetrics(t *testing.T) {
 	assert := assert.New(t)
-	fetcher := CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	fetcher := CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	nodeMetrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	metrics := fetchNodeTotalMemMetrics(nodeMetrics)
@@ -74,7 +90,11 @@ func TestNodeCollector(t *testing.T) {
 	assert.Nil(err)
 	nc := NewNodeCollecter(config)
 	// cache miss, use our mock fetcher
-	nc.fetcher = &CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	nc.fetcher = &CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	metricChan := make(chan prometheus.Metric)
 	go func() {
 		nc.Collect(metricChan)
@@ -94,7 +114,11 @@ func TestNodeDescribe(t *testing.T) {
 	config, err := NewConfig()
 	assert.Nil(err)
 	jc := NewNodeCollecter(config)
-	jc.fetcher = &CliJsonMetricFetcher{fetcher: MockNodeInfoFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	jc.fetcher = &CliJsonMetricFetcher{
+		fetcher:      MockNodeInfoFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	go func() {
 		jc.Describe(ch)
 		close(ch)
@@ -109,7 +133,11 @@ func TestNodeDescribe(t *testing.T) {
 func TestParseFallbackNodeMetrics(t *testing.T) {
 	assert := assert.New(t)
 	byteFetcher := &MockFetcher{fixture: "fixtures/sinfo_fallback.txt"}
-	fetcher := CliFallbackMetricFetcher{fetcher: byteFetcher, errorCounter: prometheus.NewCounter(prometheus.CounterOpts{})}
+	fetcher := CliFallbackMetricFetcher{
+		fetcher:      byteFetcher,
+		errorCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+		cache:        NewAtomicThrottledCache[NodeMetric](1),
+	}
 	metrics, err := fetcher.FetchMetrics()
 	assert.Nil(err)
 	assert.NotEmpty(metrics)

--- a/trace_test.go
+++ b/trace_test.go
@@ -102,8 +102,12 @@ func TestTraceControllerCollect(t *testing.T) {
 	config := &Config{
 		pollLimit: 10,
 		traceConf: &TraceConfig{
-			rate:          10,
-			sharedFetcher: MockJobInfoFetcher,
+			rate: 10,
+			sharedFetcher: &JobJsonFetcher{
+				scraper:    MockJobInfoFetcher,
+				cache:      NewAtomicThrottledCache[JobMetric](1),
+				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+			},
 		},
 		cliOpts: new(CliOpts),
 	}
@@ -128,8 +132,12 @@ func TestTraceControllerCollect_Fallback(t *testing.T) {
 	config := &Config{
 		pollLimit: 10,
 		traceConf: &TraceConfig{
-			rate:          10,
-			sharedFetcher: &MockFetcher{fixture: "fixtures/squeue_fallback.txt"},
+			rate: 10,
+			sharedFetcher: &JobCliFallbackFetcher{
+				scraper:    &MockFetcher{fixture: "fixtures/squeue_fallback.txt"},
+				cache:      NewAtomicThrottledCache[JobMetric](1),
+				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+			},
 		},
 		cliOpts: &CliOpts{fallback: true},
 	}
@@ -154,8 +162,12 @@ func TestTraceControllerDescribe(t *testing.T) {
 	config := &Config{
 		pollLimit: 10,
 		traceConf: &TraceConfig{
-			rate:          10,
-			sharedFetcher: MockJobInfoFetcher,
+			rate: 10,
+			sharedFetcher: &JobJsonFetcher{
+				scraper:    MockJobInfoFetcher,
+				cache:      NewAtomicThrottledCache[JobMetric](1),
+				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
+			},
 		},
 		cliOpts: new(CliOpts),
 	}

--- a/trace_test.go
+++ b/trace_test.go
@@ -104,7 +104,7 @@ func TestTraceControllerCollect(t *testing.T) {
 		traceConf: &TraceConfig{
 			rate: 10,
 			sharedFetcher: &JobJsonFetcher{
-				scraper:    MockJobInfoFetcher,
+				scraper:    MockJobInfoScraper,
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -134,7 +134,7 @@ func TestTraceControllerCollect_Fallback(t *testing.T) {
 		traceConf: &TraceConfig{
 			rate: 10,
 			sharedFetcher: &JobCliFallbackFetcher{
-				scraper:    &MockFetcher{fixture: "fixtures/squeue_fallback.txt"},
+				scraper:    &MockScraper{fixture: "fixtures/squeue_fallback.txt"},
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -164,7 +164,7 @@ func TestTraceControllerDescribe(t *testing.T) {
 		traceConf: &TraceConfig{
 			rate: 10,
 			sharedFetcher: &JobJsonFetcher{
-				scraper:    MockJobInfoFetcher,
+				scraper:    MockJobInfoScraper,
 				cache:      NewAtomicThrottledCache[JobMetric](1),
 				errCounter: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
@@ -194,7 +194,7 @@ func TestPython3Wrapper(t *testing.T) {
 		t.Skip()
 	}
 	assert := assert.New(t)
-	fetcher := NewCliFetcher("python3", "wrappers/proctrac.py", "--cmd", "sleep", "100", "--jobid=10", "--validate")
+	fetcher := NewCliScraper("python3", "wrappers/proctrac.py", "--cmd", "sleep", "100", "--jobid=10", "--validate")
 	t.Logf("cmd: %+v", fetcher.args)
 	wrapperOut, err := fetcher.FetchRawBytes()
 	assert.Nil(err)

--- a/utils.go
+++ b/utils.go
@@ -22,7 +22,7 @@ import (
 
 type SlurmPrimitiveMetric interface {
 	// TODO: remove byte type
-	NodeMetric | JobMetric | DiagMetric | LicenseMetric | byte
+	NodeMetric | JobMetric | DiagMetric | LicenseMetric
 }
 
 // interface for getting data from slurm

--- a/utils_test.go
+++ b/utils_test.go
@@ -104,46 +104,55 @@ func TestCliFetcher_StdErr(t *testing.T) {
 
 func TestAtomicThrottledCache_CompMiss(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache[byte](10)
-	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
+	cache := NewAtomicThrottledCache[NodeMetric](10)
 	// empty cache scenario
-	info, err := cache.FetchOrThrottle(fetcher.Fetch)
+	called := false
+	host := "host1"
+	info, err := cache.FetchOrThrottle(func() ([]NodeMetric, error) {
+		called = true
+		return []NodeMetric{{Hostname: host}}, nil
+	})
 	assert.Nil(err)
-	assert.Equal(info, fetcher.msg)
+	assert.Equal(info[0].Hostname, host)
 	// assert no cache hit
-	assert.True(fetcher.called)
+	assert.True(called)
 	// assert cache populated
-	assert.Positive(cache.cache, fetcher.msg)
+	assert.Positive(cache.cache[0].Hostname, host)
 }
 
 func TestAtomicThrottledCache_Hit(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache[byte](math.MaxFloat64)
-	cache.cache = []byte("cache")
-	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
+	cache := NewAtomicThrottledCache[NodeMetric](math.MaxFloat64)
+	cache.cache = []NodeMetric{{Hostname: "host1"}}
 	// empty cache scenario
-	info, err := cache.FetchOrThrottle(fetcher.Fetch)
+	called := false
+	info, err := cache.FetchOrThrottle(func() ([]NodeMetric, error) {
+		called = true
+		return []NodeMetric{{Hostname: "host2"}}, nil
+	})
 	assert.Nil(err)
-	assert.Equal(info, cache.cache)
+	assert.Equal(info[0].Hostname, "host1")
 	// assert fetch not called
-	assert.False(fetcher.called)
+	assert.False(called)
 	// assert cache populated
-	assert.Positive(len(cache.cache))
+	assert.NotEmpty(cache.cache)
 }
 
 func TestAtomicThrottledCache_Stale(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache[byte](0)
-	cache.cache = []byte("cache")
-	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
-	// empty cache scenario
-	info, err := cache.FetchOrThrottle(fetcher.Fetch)
+	cache := NewAtomicThrottledCache[NodeMetric](0)
+	cache.cache = []NodeMetric{{Hostname: "host1"}}
+	called := false
+	info, err := cache.FetchOrThrottle(func() ([]NodeMetric, error) {
+		called = true
+		return []NodeMetric{{Hostname: "host2"}}, nil
+	})
 	assert.Nil(err)
-	assert.Equal(info, fetcher.msg)
+	assert.Equal(info[0].Hostname, "host2")
 	// assert fetch not called
-	assert.True(fetcher.called)
+	assert.True(called)
 	// assert cache populated
-	assert.Equal(cache.cache, fetcher.msg)
+	assert.Equal(cache.cache[0].Hostname, "host2")
 }
 
 func TestConvertMemToFloat(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -107,7 +107,7 @@ func TestAtomicThrottledCache_CompMiss(t *testing.T) {
 	cache := NewAtomicThrottledCache[byte](10)
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
-	info, err := cache.fetchOrThrottle(fetcher.Fetch)
+	info, err := cache.FetchOrThrottle(fetcher.Fetch)
 	assert.Nil(err)
 	assert.Equal(info, fetcher.msg)
 	// assert no cache hit
@@ -122,7 +122,7 @@ func TestAtomicThrottledCache_Hit(t *testing.T) {
 	cache.cache = []byte("cache")
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
-	info, err := cache.fetchOrThrottle(fetcher.Fetch)
+	info, err := cache.FetchOrThrottle(fetcher.Fetch)
 	assert.Nil(err)
 	assert.Equal(info, cache.cache)
 	// assert fetch not called
@@ -137,7 +137,7 @@ func TestAtomicThrottledCache_Stale(t *testing.T) {
 	cache.cache = []byte("cache")
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
-	info, err := cache.fetchOrThrottle(fetcher.Fetch)
+	info, err := cache.FetchOrThrottle(fetcher.Fetch)
 	assert.Nil(err)
 	assert.Equal(info, fetcher.msg)
 	// assert fetch not called

--- a/utils_test.go
+++ b/utils_test.go
@@ -61,7 +61,7 @@ func (f *MockFetchErrored) Duration() time.Duration {
 
 func TestCliFetcher(t *testing.T) {
 	assert := assert.New(t)
-	cliFetcher := NewCliFetcher("ls")
+	cliFetcher := NewCliScraper("ls")
 	data, err := cliFetcher.FetchRawBytes()
 	assert.Nil(err)
 	assert.NotNil(data)
@@ -69,7 +69,7 @@ func TestCliFetcher(t *testing.T) {
 
 func TestCliFetcher_Timeout(t *testing.T) {
 	assert := assert.New(t)
-	cliFetcher := NewCliFetcher("sleep", "100")
+	cliFetcher := NewCliScraper("sleep", "100")
 	cliFetcher.timeout = 0
 	data, err := cliFetcher.FetchRawBytes()
 	assert.EqualError(err, "signal: killed")
@@ -78,7 +78,7 @@ func TestCliFetcher_Timeout(t *testing.T) {
 
 func TestCliFetcher_EmptyArgs(t *testing.T) {
 	assert := assert.New(t)
-	cliFetcher := NewCliFetcher()
+	cliFetcher := NewCliScraper()
 	data, err := cliFetcher.FetchRawBytes()
 	assert.EqualError(err, "need at least 1 args")
 	assert.Nil(data)
@@ -86,7 +86,7 @@ func TestCliFetcher_EmptyArgs(t *testing.T) {
 
 func TestCliFetcher_ExitCodeCmd(t *testing.T) {
 	assert := assert.New(t)
-	cliFetcher := NewCliFetcher("ls", generateRandString(64))
+	cliFetcher := NewCliScraper("ls", generateRandString(64))
 	data, err := cliFetcher.FetchRawBytes()
 	assert.NotNil(err)
 	assert.Nil(data)
@@ -96,7 +96,7 @@ func TestCliFetcher_StdErr(t *testing.T) {
 	assert := assert.New(t)
 	// the rare case where stderr is written but exit code is still 0
 	cmd := `echo -e "error" 1>&2`
-	cliFetcher := NewCliFetcher("/bin/bash", "-c", cmd)
+	cliFetcher := NewCliScraper("/bin/bash", "-c", cmd)
 	data, err := cliFetcher.FetchRawBytes()
 	assert.NotNil(err)
 	assert.Nil(data)

--- a/utils_test.go
+++ b/utils_test.go
@@ -104,7 +104,7 @@ func TestCliFetcher_StdErr(t *testing.T) {
 
 func TestAtomicThrottledCache_CompMiss(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache(10)
+	cache := NewAtomicThrottledCache[byte](10)
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
 	info, err := cache.fetchOrThrottle(fetcher.Fetch)
@@ -118,7 +118,7 @@ func TestAtomicThrottledCache_CompMiss(t *testing.T) {
 
 func TestAtomicThrottledCache_Hit(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache(math.MaxFloat64)
+	cache := NewAtomicThrottledCache[byte](math.MaxFloat64)
 	cache.cache = []byte("cache")
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario
@@ -133,7 +133,7 @@ func TestAtomicThrottledCache_Hit(t *testing.T) {
 
 func TestAtomicThrottledCache_Stale(t *testing.T) {
 	assert := assert.New(t)
-	cache := NewAtomicThrottledCache(0)
+	cache := NewAtomicThrottledCache[byte](0)
 	cache.cache = []byte("cache")
 	fetcher := &MockFetchTriggered{msg: []byte("mocked")}
 	// empty cache scenario


### PR DESCRIPTION
Generic atomic cache. Taking the cache out of the byte fetcher and moving it up one abstraction layer. This will allow us to use this out of the box in our CFetcher