### PR TITLE
[jobs] state label for user alloc metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also install the exporter directly with `go install github.com/rivosinc/
 
 ```bash
 # example installation
-$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.2.1
+$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.3.1
 # or if you like living on the edge
 $ go install github.com/rivosinc/prometheus-slurm-exporter@latest
 # if not already added, ensure

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -58,7 +58,7 @@ func TestParseJobMetrics(t *testing.T) {
 		}
 	}
 	assert.NotNil(job)
-	assert.Equal(float64(64000), totalAllocMem(&job.JobResources))
+	assert.Equal(6.4e13, totalAllocMem(&job.JobResources))
 }
 
 func TestParseCliFallback(t *testing.T) {
@@ -83,10 +83,17 @@ func TestUserJobMetric(t *testing.T) {
 
 	//test
 	state := "RUNNING"
-	for _, metric := range parseUserJobMetrics(jms) {
-		assert.Positive(metric.allocCpu[state])
-		assert.Positive(metric.allocMemory[state])
-		assert.Positive(metric.stateJobCount[state])
+	expectedUser := "bkd"
+
+	for user, metric := range parseUserJobMetrics(jms) {
+		if user == expectedUser {
+			assert.Equal(1., metric.totalJobCount)
+			assert.Equal(1., metric.allocCpu[state])
+			assert.Equal(1., metric.stateJobCount[state])
+			assert.Equal(6.4e+13, metric.allocMemory[state])
+		} else {
+			t.Fatal("unexpected user in reseult")
+		}
 	}
 }
 

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -5,7 +5,6 @@
 package exporter
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -83,9 +82,11 @@ func TestUserJobMetric(t *testing.T) {
 	assert.Nil(err)
 
 	//test
+	state := "RUNNING"
 	for _, metric := range parseUserJobMetrics(jms) {
-		assert.Positive(metric.allocCpu)
-		assert.Positive(metric.allocMemory)
+		assert.Positive(metric.allocCpu[state])
+		assert.Positive(metric.allocMemory[state])
+		assert.Positive(metric.stateJobCount[state])
 	}
 }
 
@@ -167,7 +168,6 @@ func TestParsePartMetrics(t *testing.T) {
 	assert.Nil(err)
 
 	featureMetrics := parseFeatureMetric(jms)
-	fmt.Println(featureMetrics)
 	assert.Equal(1., featureMetrics["a100-80gb"].total)
 	assert.Equal(1., featureMetrics["preemptible"].allocCpu)
 }


### PR DESCRIPTION
Add state label to user alloc mem metric. Will push updated dashboard soon as well. New metrics:

```
slurm_user_cpu_alloc{state="PENDING",username="user"} 8
slurm_user_mem_alloc{state="PENDING",username="user"} 4e+09