### PR TITLE
[ci] bump to node 20 actions

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: reuse Compliance Check
       uses: fsfe/reuse-action@v1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
     - uses: actions/setup-go@v5
       with:
         go-version: '>=1.20'
@@ -22,7 +24,9 @@ jobs:
     needs: pre-commit
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
     - uses: actions/setup-go@v5
     - run: pip install psutil requests
     - run: CGO_ENABLED=0 go test ./exporter

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,9 +10,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '>=1.20'
     - uses: pre-commit/action@v3.0.0
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: actions/setup-go@v5
     - run: pip install psutil requests
     - run: CGO_ENABLED=0 go test ./exporter

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '>=1.20'
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Actions have to be migrated soon: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/