### PR TITLE
[exporter] expand all slurm arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also install the exporter directly with `go install github.com/rivosinc/
 
 ```bash
 # example installation
-$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.4.1
+$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.5.1
 # or if you like living on the edge
 $ go install github.com/rivosinc/prometheus-slurm-exporter@latest
 # if not already added, ensure

--- a/exporter/fixtures/squeue_fallback.txt
+++ b/exporter/fixtures/squeue_fallback.txt
@@ -1,7 +1,7 @@
-{"a": "account1", "id": 26515966, "end_time": "2023-09-21T00:21:42", "state": "RUNNING", "p": "hw-h", "cpu": 1, "mem": "128G"}
-{"a": "account1", "id": 50580016, "end_time": "2023-09-21T14:31:11", "state": "RUNNING", "p": "hw-l", "cpu": 1, "mem": "62.50G"}
-{"a": "account1", "id": 51447051, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M"}
-{"a": "account1", "id": 18804, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": 24, "mem": "118G"}
+{"a": "account1", "id": 26515966, "end_time": "2023-09-21T00:21:42", "state": "RUNNING", "p": "hw-h", "cpu": 1, "mem": "128G", "array_id": "N/A"}
+{"a": "account1", "id": 50580016, "end_time": "2023-09-21T14:31:11", "state": "RUNNING", "p": "hw-l", "cpu": 1, "mem": "62.50G", "array_id": "N/A"}
+{"a": "account1", "id": 51447051, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M", "array_id": "N/A"}
+{"a": "account1", "id": 18804, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": 24, "mem": "118G", "array_id": "N/A"}
 # test counter inc with faulty inputs
-{"a": "account1", "id": 18805, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G"}
-{"a": "account1", "id": 18806, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G"}
+{"a": "account1", "id": 18805, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G", "array_id": "N/A"}
+{"a": "account1", "id": 18806, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G", "array_id": "N/A"}

--- a/exporter/main_test.go
+++ b/exporter/main_test.go
@@ -74,7 +74,7 @@ func TestNewConfig_NonDefault(t *testing.T) {
 	cliFlags := CliFlags{SlurmCliFallback: true}
 	config, err := NewConfig(&cliFlags)
 	assert.Nil(err)
-	expected := []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
+	expected := []string{"squeue", "--states=all", "-h", "-r", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m", "array_id": "%K"}`}
 	assert.Equal(expected, config.cliOpts.squeue)
 }
 

--- a/exporter/server.go
+++ b/exporter/server.go
@@ -139,7 +139,7 @@ func NewConfig(cliFlags *CliFlags) (*Config, error) {
 	}
 	if cliOpts.fallback {
 		// we define a custom json format that we convert back into the openapi format
-		cliOpts.squeue = []string{"squeue", "--states=all", "-h", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m"}`}
+		cliOpts.squeue = []string{"squeue", "--states=all", "-h", "-r", "-o", `{"a": "%a", "id": %A, "end_time": "%e", "u": "%u", "state": "%T", "p": "%P", "cpu": %C, "mem": "%m", "array_id": "%K"}`}
 		cliOpts.sinfo = []string{"sinfo", "-h", "-o", `{"s": "%T", "mem": %m, "n": "%n", "l": "%O", "p": "%R", "fmem": "%e", "cstate": "%C", "w": %w}`}
 		traceConf.sharedFetcher = &JobCliFallbackFetcher{
 			scraper: NewCliScraper(cliOpts.squeue...),

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 	slurmDiagOverride    = flag.String("slurm.diag-cli", "", "sdiag cli override")
 	slurmLicEnabled      = flag.Bool("slurm.collect-licenses", false, "Collect license info from slurm")
 	slurmDiagEnabled     = flag.Bool("slurm.collect-diags", false, "Collect daemon diagnostics stats from slurm")
-	slurmCliFallback     = flag.Bool("slurm.cli-fallback", false, "drop the --json arg and revert back to standard squeue for performance reasons")
+	slurmCliFallback     = flag.Bool("slurm.cli-fallback", true, "drop the --json arg and revert back to standard squeue for performance reasons")
 )
 
 func main() {


### PR DESCRIPTION
slurm arrays that are `pending` show up as one line. The `-r` option removes this optimization. Eventually, we can support parsing the array string, but there is quite a bit to the format and after a couple preliminary perf tests, the scrape duration seems unaffected. Will do some more perf testing before merging and will publish the dashboard pre and post change