### PR TITLE
[exporter/utils] mem conversion float err

### DIFF
--- a/exporter/jobs.go
+++ b/exporter/jobs.go
@@ -138,8 +138,15 @@ func (nat *NAbleTime) UnmarshalJSON(data []byte) error {
 
 func parseCliFallback(squeue []byte, errorCounter prometheus.Counter) ([]JobMetric, error) {
 	jobMetrics := make([]JobMetric, 0)
-	// convert our custom format to the openapi format we expect
-	for i, line := range bytes.Split(bytes.Trim(squeue, "\n"), []byte("\n")) {
+	// clean input
+	squeue = bytes.TrimSpace(squeue)
+	squeue = bytes.Trim(squeue, "\n")
+	if len(squeue) == 0 {
+		// handle no jobs returned
+		return nil, nil
+	}
+
+	for i, line := range bytes.Split(squeue, []byte("\n")) {
 		var metric struct {
 			Account   string    `json:"a"`
 			JobId     float64   `json:"id"`

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -219,3 +219,18 @@ func TestNAbleTimeJson_NA(t *testing.T) {
 	assert.Nil(err)
 	assert.True(nat.Equal(time.Time{}))
 }
+
+func TestParseCliFallbackEmpty(t *testing.T) {
+	assert := assert.New(t)
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "validation_counter",
+	})
+	metrics, err := parseCliFallback([]byte(""), counter)
+	assert.NoError(err)
+	assert.Empty(metrics)
+	assert.Zero(CollectCounterValue(counter))
+	metrics, err = parseCliFallback([]byte("\n "), counter)
+	assert.NoError(err)
+	assert.Empty(metrics)
+	assert.Zero(CollectCounterValue(counter))
+}

--- a/exporter/utils.go
+++ b/exporter/utils.go
@@ -169,7 +169,7 @@ func MemToFloat(mem string) (float64, error) {
 	if num, err := strconv.ParseFloat(mem, 64); err == nil {
 		return num, nil
 	}
-	memUnits := map[string]int{
+	memUnits := map[string]float64{
 		"M": 1e+6,
 		"G": 1e+9,
 		"T": 1e+12,
@@ -182,5 +182,5 @@ func MemToFloat(mem string) (float64, error) {
 	// err here should be impossible due to regex
 	num, err := strconv.ParseFloat(matches[re.SubexpIndex("num")], 64)
 	memunit := memUnits[matches[re.SubexpIndex("memunit")]]
-	return num * float64(memunit), err
+	return num * memunit, err
 }


### PR DESCRIPTION
Change the datatype for mem string conversion. The map shouldn't really have ever had int value types as we cast and return a float anyway.

resolves #71 