### PR TITLE
[exporter/limits] bug-fix limit mb conversion

### DIFF
--- a/exporter/limits.go
+++ b/exporter/limits.go
@@ -61,7 +61,7 @@ func (acf *AccountCsvFetcher) fetchFromCli() ([]AccountLimitMetric, error) {
 				slog.Error("failed to scrape account metric mem string %s", mem)
 				acf.errorCounter.Inc()
 			} else {
-				metric.Mem = memMb * 1000
+				metric.Mem = memMb * 1e6
 			}
 		}
 		if cpu != "" {

--- a/exporter/limits_test.go
+++ b/exporter/limits_test.go
@@ -25,7 +25,7 @@ func TestAccountLimitFetch(t *testing.T) {
 	account1Limit := accountLimits[0]
 	assert.Equal(account1Limit.Account, "account1")
 	assert.Equal(account1Limit.CPU, 964.)
-	assert.Equal(account1Limit.Mem, 15468557.*1000)
+	assert.Equal(account1Limit.Mem, 15468557.*1e6)
 }
 
 func TestNewLimitCollector(t *testing.T) {


### PR DESCRIPTION
Patch a bug where account mem alloc limits was reported in Kb instead of bytes.