### PR TITLE
[exporter/node] total node count per partition per metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also install the exporter directly with `go install github.com/rivosinc/
 
 ```bash
 # example installation
-$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.6.2
+$ go install github.com/rivosinc/prometheus-slurm-exporter@v1.6.3
 # or if you like living on the edge
 $ go install github.com/rivosinc/prometheus-slurm-exporter@latest
 # if not already added, ensure

--- a/exporter/nodes_test.go
+++ b/exporter/nodes_test.go
@@ -66,6 +66,7 @@ func TestPartitionMetric(t *testing.T) {
 	assert.Equal(1.823573e+06, metrics["hw"].FreeMemory)
 	assert.Equal(2e+06, metrics["hw"].RealMemory)
 	assert.Equal(252., metrics["hw"].IdleCpus)
+	assert.Equal(4., sumStateMetric(metrics["hw"].StateNodeCount))
 }
 
 func TestNodeSummaryCpuMetric(t *testing.T) {


### PR DESCRIPTION
Add metric to count the number of nodes per state per partition.


Try out the branch with the following:

```bash
go install github.com/rivosinc/prometheus-slurm-exporter@partition-state-node-count
```

resolves #84 


cc @AndyMcVey