### PR TITLE
[exporter/jobs] fix JobMetric Fetcher cache bug

### DIFF
--- a/exporter/mock_utils.go
+++ b/exporter/mock_utils.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 Rivos Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exporter
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"time"
+)
+
+type MockFetchErrored struct{}
+
+func (f *MockFetchErrored) FetchRawBytes() ([]byte, error) {
+	return nil, errors.New("mock fetch error")
+}
+
+func (f *MockFetchErrored) Duration() time.Duration {
+	return 1
+}
+
+// implements SlurmByteScraper by pulling fixtures instead
+// used exclusively for testing
+type MockScraper struct {
+	fixture   string
+	duration  time.Duration
+	CallCount int
+}
+
+func (f *MockScraper) FetchRawBytes() ([]byte, error) {
+	defer func(t time.Time) {
+		f.duration = time.Since(t)
+	}(time.Now())
+	f.CallCount++
+	file, err := os.ReadFile(f.fixture)
+	if err != nil {
+		return nil, err
+	}
+	// allow commenting in text files
+	sep := []byte("\n")
+	lines := bytes.Split(file, sep)
+	filtered := make([][]byte, 0)
+	for _, line := range lines {
+		if !bytes.HasPrefix(line, []byte("#")) {
+			filtered = append(filtered, line)
+		}
+	}
+	return bytes.Join(filtered, sep), nil
+}
+
+func (f *MockScraper) Duration() time.Duration {
+	return f.duration
+}
+
+// implements SlurmByteScraper by emmiting string payload instead
+// used exclusively for testing
+type StringByteScraper struct {
+	msg       string
+	Callcount int
+}
+
+func (es *StringByteScraper) FetchRawBytes() ([]byte, error) {
+	es.Callcount++
+	return []byte(es.msg), nil
+}
+
+func (es *StringByteScraper) Duration() time.Duration {
+	return time.Duration(1)
+}

--- a/exporter/utils.go
+++ b/exporter/utils.go
@@ -136,14 +136,16 @@ func NewCliScraper(args ...string) *CliScraper {
 // implements SlurmByteScraper by pulling fixtures instead
 // used exclusively for testing
 type MockScraper struct {
-	fixture  string
-	duration time.Duration
+	fixture   string
+	duration  time.Duration
+	CallCount int
 }
 
 func (f *MockScraper) FetchRawBytes() ([]byte, error) {
 	defer func(t time.Time) {
 		f.duration = time.Since(t)
 	}(time.Now())
+	f.CallCount++
 	file, err := os.ReadFile(f.fixture)
 	if err != nil {
 		return nil, err
@@ -162,6 +164,22 @@ func (f *MockScraper) FetchRawBytes() ([]byte, error) {
 
 func (f *MockScraper) Duration() time.Duration {
 	return f.duration
+}
+
+// implements SlurmByteScraper by emmiting string payload instead
+// used exclusively for testing
+type StringByteScraper struct {
+	msg       string
+	Callcount int
+}
+
+func (es *StringByteScraper) FetchRawBytes() ([]byte, error) {
+	es.Callcount++
+	return []byte(es.msg), nil
+}
+
+func (es *StringByteScraper) Duration() time.Duration {
+	return time.Duration(1)
 }
 
 // convert slurm mem string to float64 bytes

--- a/exporter/utils.go
+++ b/exporter/utils.go
@@ -133,55 +133,6 @@ func NewCliScraper(args ...string) *CliScraper {
 	}
 }
 
-// implements SlurmByteScraper by pulling fixtures instead
-// used exclusively for testing
-type MockScraper struct {
-	fixture   string
-	duration  time.Duration
-	CallCount int
-}
-
-func (f *MockScraper) FetchRawBytes() ([]byte, error) {
-	defer func(t time.Time) {
-		f.duration = time.Since(t)
-	}(time.Now())
-	f.CallCount++
-	file, err := os.ReadFile(f.fixture)
-	if err != nil {
-		return nil, err
-	}
-	// allow commenting in text files
-	sep := []byte("\n")
-	lines := bytes.Split(file, sep)
-	filtered := make([][]byte, 0)
-	for _, line := range lines {
-		if !bytes.HasPrefix(line, []byte("#")) {
-			filtered = append(filtered, line)
-		}
-	}
-	return bytes.Join(filtered, sep), nil
-}
-
-func (f *MockScraper) Duration() time.Duration {
-	return f.duration
-}
-
-// implements SlurmByteScraper by emmiting string payload instead
-// used exclusively for testing
-type StringByteScraper struct {
-	msg       string
-	Callcount int
-}
-
-func (es *StringByteScraper) FetchRawBytes() ([]byte, error) {
-	es.Callcount++
-	return []byte(es.msg), nil
-}
-
-func (es *StringByteScraper) Duration() time.Duration {
-	return time.Duration(1)
-}
-
 // convert slurm mem string to float64 bytes
 func MemToFloat(mem string) (float64, error) {
 	if num, err := strconv.ParseFloat(mem, 64); err == nil {

--- a/exporter/utils_test.go
+++ b/exporter/utils_test.go
@@ -5,7 +5,6 @@
 package exporter
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -32,31 +31,6 @@ func generateRandString(n int) string {
 		randBytes[i] = chars[seededRand.Int()%len(chars)]
 	}
 	return string(randBytes)
-}
-
-// used to ensure the fetch function was called
-type MockFetchTriggered struct {
-	msg    []byte
-	called bool
-}
-
-func (f *MockFetchTriggered) Fetch() ([]byte, error) {
-	f.called = true
-	return f.msg, nil
-}
-
-func (f *MockFetchTriggered) Duration() time.Duration {
-	return 1
-}
-
-type MockFetchErrored struct{}
-
-func (f *MockFetchErrored) FetchRawBytes() ([]byte, error) {
-	return nil, errors.New("mock fetch error")
-}
-
-func (f *MockFetchErrored) Duration() time.Duration {
-	return 1
 }
 
 func TestCliFetcher(t *testing.T) {


### PR DESCRIPTION
This bug has been in the exporter for a while where the incorrect components were cache. Only the parsing of the test output was cached, not the scraping of said output. This PR red-green covers said bug

## Testing

  - Unit and module tested
  - Inserted a debug log in the scraper, ran `just devel`, and observed the scraper only  being called after `POLL_LIMIT` expiration.
  - Deployed to production on rivos internal cluster.

cc @drewstinnett

resolves #98 