### PR TITLE
[exporter/jobs] consolidate node not avail reason

### DIFF
--- a/exporter/fixtures/squeue_fallback.txt
+++ b/exporter/fixtures/squeue_fallback.txt
@@ -1,6 +1,8 @@
 {"a": "account1", "id": 26515966, "end_time": "2023-09-21T00:21:42", "state": "RUNNING", "p": "hw-h", "cpu": 1, "mem": "128G", "array_id": "N/A", "r":  "cs10"}
 {"a": "account1", "id": 50580016, "end_time": "2023-09-21T14:31:11", "state": "RUNNING", "p": "hw-l", "cpu": 1, "mem": "62.50G", "array_id": "N/A", "r":  "cs10"}
 {"a": "account1", "id": 51447051, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M", "array_id": "N/A", "r":  "(Dependency)"}
+{"a": "account1", "id": 51447052, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M", "array_id": "N/A", "r":  "((ReqNodeNotAvail, UnavailableNodes:cs[100,101,102]))"}
+{"a": "account1", "id": 51447053, "end_time": "N/A", "state": "PENDING", "p": "hw-h", "cpu": 1, "mem": "40000M", "array_id": "N/A", "r":  "(Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions)"}
 {"a": "account1", "id": 18804, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": 24, "mem": "118G", "array_id": "N/A", "r":  "(Priority)"}
 # test counter inc with faulty inputs
 {"a": "account1", "id": 18805, "end_time": "NONE", "state": "PENDING", "p": "magma", "cpu": xx, "mem": "118G", "array_id": "N/A"}

--- a/exporter/jobs.go
+++ b/exporter/jobs.go
@@ -135,7 +135,7 @@ func (jcf *JobCliFallbackFetcher) fetch() ([]JobMetric, error) {
 			jcf.errCounter.Inc()
 			continue
 		}
-		re := regexp.MustCompile(`^\((?P<reason>(\w)+)\)$`)
+		re := regexp.MustCompile(`^\((?P<reason>(.+))\)$`)
 		if metric.JobState == "PENDING" {
 			if matches := re.FindStringSubmatch(metric.StateReason); matches != nil {
 				metric.StateReason = matches[re.SubexpIndex("reason")]

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -5,6 +5,7 @@
 package exporter
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +75,13 @@ func TestParseCliFallback(t *testing.T) {
 	metrics, err := cliFallbackFetcher.fetch()
 	assert.Nil(err)
 	assert.NotEmpty(metrics)
+	nodeAvailMetricsCount := 0
+	for _, metric := range metrics {
+		if strings.Contains(metric.StateReason, reqNodeNotAvailReason) {
+			nodeAvailMetricsCount++
+		}
+	}
+	assert.Equal(1, nodeAvailMetricsCount)
 	assert.Equal(2., CollectCounterValue(cliFallbackFetcher.errCounter))
 }
 


### PR DESCRIPTION
Consolidate the unavailable node reason from

```shell
(ReqNodeNotAvail, UnavailableNodes:cs[100,101,102,...])
```

To 

```shell
(ReqNodeNotAvail, UnavailableNodes)
```

and allow spaces in state reason in response to the following logs:

```shell
level=ERROR msg="squeue failed to pull pending state reason. Got state reason: (Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions)"
```

## Testing

  * unit tests modified