### PR TITLE
[ci] release cgo disabled builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 version: 2
 builds:
-  - goos:
+  - env:
+      - CGO_ENABLED=0
+    goos:
       - linux
     goarch:
       - amd64


### PR DESCRIPTION
Getting GlibC mismatch errors while installing on certain OS' 

```bash
prometheus-slurm-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by prometheus-slurm-exporter)
prometheus-slurm-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by prometheus-slurm-exporter)
```