### PR TITLE
[exporter/diags] make json sdiag response struct 24.05 comptible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM --platform=linux/amd64 ubuntu:20.04
 SHELL ["/bin/bash", "-c"]
-ARG SLURM_VERSION="23-02-5-1"
+ARG SLURM_VERSION="24-05-5-1"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIRBARY_PATH=/usr/lib64/lib/slurm
 ENV PATH=/usr/lib64/bin:/usr/lib64/sbin:/root/.cargo/bin:/usr/local/go/bin:$PATH
@@ -40,9 +40,9 @@ RUN mkdir -p /etc/slurm && \
 # install go deps
 RUN arch=`uname -m` && \
     if [ $arch == "aarch64" ]; then arch="arm64"; elif [ "$arch" == "x86_64" ]; then arch="amd64" ;fi && \
-    wget "https://go.dev/dl/go1.20.12.linux-${arch}.tar.gz" && \
-    tar -C /usr/local -xzf "go1.20.12.linux-${arch}.tar.gz" && \
-    rm "go1.20.12.linux-${arch}.tar.gz" && \
+    wget "https://go.dev/dl/go1.23.1.linux-${arch}.tar.gz" && \
+    tar -C /usr/local -xzf "go1.23.1.linux-${arch}.tar.gz" && \
+    rm "go1.23.1.linux-${arch}.tar.gz" && \
     mkdir /src
 
 # default wrapper deps for e2e tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM --platform=linux/amd64 ubuntu:20.04
 SHELL ["/bin/bash", "-c"]
-ARG SLURM_VERSION="24-05-5-1"
+ARG SLURM_VERSION="23-02-5-1"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIRBARY_PATH=/usr/lib64/lib/slurm
 ENV PATH=/usr/lib64/bin:/usr/lib64/sbin:/root/.cargo/bin:/usr/local/go/bin:$PATH

--- a/exporter/diags_test.go
+++ b/exporter/diags_test.go
@@ -40,6 +40,25 @@ func TestDiagCollect(t *testing.T) {
 	assert.NotEmpty(metrics)
 }
 
+func TestDiagCollect_2405(t *testing.T) {
+	assert := assert.New(t)
+	config, err := NewConfig(new(CliFlags))
+	assert.NoError(err)
+	dc := NewDiagsCollector(config)
+	dc.fetcher = &MockScraper{fixture: "fixtures/sdiag_2405.json"}
+	metricChan := make(chan prometheus.Metric)
+	go func() {
+		dc.Collect(metricChan)
+		close(metricChan)
+	}()
+	metrics := make([]prometheus.Metric, 0)
+	for m, ok := <-metricChan; ok; m, ok = <-metricChan {
+		metrics = append(metrics, m)
+		t.Logf("Received metric %s", m.Desc().String())
+	}
+	assert.NotEmpty(metrics)
+}
+
 func TestDiagDescribe(t *testing.T) {
 	assert := assert.New(t)
 	ch := make(chan *prometheus.Desc)
@@ -56,4 +75,24 @@ func TestDiagDescribe(t *testing.T) {
 		descs = append(descs, desc)
 	}
 	assert.NotEmpty(descs)
+}
+
+func TestDataParserVersionDiscovery_Slurm23(t *testing.T) {
+	assert := assert.New(t)
+	fetcher := MockScraper{fixture: "fixtures/sdiag.json"}
+	sdiag, err := fetcher.FetchRawBytes()
+	assert.NoError(err)
+	resp, err := parseDiagMetrics(sdiag)
+	assert.NoError(err)
+	assert.True(resp.IsDataParserPlugin())
+}
+
+func TestDataParserVersionDiscovery_Slurm24(t *testing.T) {
+	assert := assert.New(t)
+	fetcher := MockScraper{fixture: "fixtures/sdiag_2405.json"}
+	sdiag, err := fetcher.FetchRawBytes()
+	assert.NoError(err)
+	resp, err := parseDiagMetrics(sdiag)
+	assert.NoError(err)
+	assert.Truef(resp.IsDataParserPlugin(), "parsed metadata struct %+v", resp.Meta)
 }

--- a/exporter/fixtures/sdiag_2405.json
+++ b/exporter/fixtures/sdiag_2405.json
@@ -1,0 +1,291 @@
+{
+  "statistics": {
+    "parts_packed": 1,
+    "req_time": {
+      "set": true,
+      "infinite": false,
+      "number": 1739832148
+    },
+    "req_time_start": {
+      "set": true,
+      "infinite": false,
+      "number": 1739822537
+    },
+    "server_thread_count": 2,
+    "agent_queue_size": 0,
+    "agent_count": 0,
+    "agent_thread_count": 0,
+    "dbd_agent_queue_size": 0,
+    "gettimeofday_latency": 33,
+    "schedule_cycle_max": 1666,
+    "schedule_cycle_last": 110,
+    "schedule_cycle_sum": 10791,
+    "schedule_cycle_total": 162,
+    "schedule_cycle_mean": 66,
+    "schedule_cycle_mean_depth": 0,
+    "schedule_cycle_per_minute": 1,
+    "schedule_cycle_depth": 0,
+    "schedule_exit": {
+      "end_job_queue": 162,
+      "default_queue_depth": 0,
+      "max_job_start": 0,
+      "max_rpc_cnt": 0,
+      "max_sched_time": 0,
+      "licenses": 0
+    },
+    "schedule_queue_length": 0,
+    "jobs_submitted": 1,
+    "jobs_started": 1,
+    "jobs_completed": 1,
+    "jobs_canceled": 0,
+    "jobs_failed": 0,
+    "jobs_pending": 0,
+    "jobs_running": 0,
+    "job_states_ts": {
+      "set": true,
+      "infinite": false,
+      "number": 1739832137
+    },
+    "bf_backfilled_jobs": 0,
+    "bf_last_backfilled_jobs": 0,
+    "bf_backfilled_het_jobs": 0,
+    "bf_cycle_counter": 0,
+    "bf_cycle_mean": 0,
+    "bf_depth_mean": 0,
+    "bf_depth_mean_try": 0,
+    "bf_cycle_sum": 0,
+    "bf_cycle_last": 0,
+    "bf_cycle_max": 0,
+    "bf_exit": {
+      "end_job_queue": 0,
+      "bf_max_job_start": 0,
+      "bf_max_job_test": 0,
+      "bf_max_time": 0,
+      "bf_node_space_size": 0,
+      "state_changed": 0
+    },
+    "bf_last_depth": 0,
+    "bf_last_depth_try": 0,
+    "bf_depth_sum": 0,
+    "bf_depth_try_sum": 0,
+    "bf_queue_len": 0,
+    "bf_queue_len_mean": 0,
+    "bf_queue_len_sum": 0,
+    "bf_table_size": 0,
+    "bf_table_size_sum": 0,
+    "bf_table_size_mean": 0,
+    "bf_when_last_cycle": {
+      "set": true,
+      "infinite": false,
+      "number": 0
+    },
+    "bf_active": false,
+    "rpcs_by_message_type": [
+      {
+        "type_id": 1002,
+        "message_type": "MESSAGE_NODE_REGISTRATION_STATUS",
+        "count": 6,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 4969,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 828
+        }
+      },
+      {
+        "type_id": 4001,
+        "message_type": "REQUEST_RESOURCE_ALLOCATION",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 17873,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 17873
+        }
+      },
+      {
+        "type_id": 4019,
+        "message_type": "REQUEST_JOB_READY",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 332,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 332
+        }
+      },
+      {
+        "type_id": 5001,
+        "message_type": "REQUEST_JOB_STEP_CREATE",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 6331,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 6331
+        }
+      },
+      {
+        "type_id": 5017,
+        "message_type": "REQUEST_COMPLETE_JOB_ALLOCATION",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 2113,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 2113
+        }
+      },
+      {
+        "type_id": 5016,
+        "message_type": "REQUEST_STEP_COMPLETE",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 739,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 739
+        }
+      },
+      {
+        "type_id": 6012,
+        "message_type": "MESSAGE_EPILOG_COMPLETE",
+        "count": 1,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 635,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 635
+        }
+      },
+      {
+        "type_id": 2035,
+        "message_type": "REQUEST_STATS_INFO",
+        "count": 5,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 1951,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 390
+        }
+      },
+      {
+        "type_id": 2009,
+        "message_type": "REQUEST_PARTITION_INFO",
+        "count": 6,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 1391,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 231
+        }
+      },
+      {
+        "type_id": 2003,
+        "message_type": "REQUEST_JOB_INFO",
+        "count": 3,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 2975,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 991
+        }
+      },
+      {
+        "type_id": 2007,
+        "message_type": "REQUEST_NODE_INFO",
+        "count": 3,
+        "queued": 0,
+        "dropped": 0,
+        "cycle_last": 0,
+        "cycle_max": 0,
+        "total_time": 1051,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 350
+        }
+      }
+    ],
+    "rpcs_by_user": [
+      {
+        "user_id": 0,
+        "user": "root",
+        "count": 29,
+        "total_time": 40360,
+        "average_time": {
+          "set": true,
+          "infinite": false,
+          "number": 1391
+        }
+      }
+    ],
+    "pending_rpcs": [],
+    "pending_rpcs_by_hostlist": []
+  },
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser/v0.0.41",
+      "accounting_storage": ""
+    },
+    "client": {
+      "source": "/dev/pts/0",
+      "user": "root",
+      "group": "root"
+    },
+    "command": ["sdiag"],
+    "slurm": {
+      "version": {
+        "major": "24",
+        "micro": "5",
+        "minor": "05"
+      },
+      "release": "24.05.5",
+      "cluster": "default-cluster"
+    }
+  },
+  "errors": [],
+  "warnings": []
+}

--- a/exporter/fixtures/sdiag_2405.json.license
+++ b/exporter/fixtures/sdiag_2405.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Monkey patch to make the json response struct for sdiag 23/24 response compatible with a handful of coercible types. These type have been tested and should be safe. A more sustainable approach would be to actually make the cli parser for sdiag using parseable and not json. For sdiag, instead of having one type of struct take the responsibility of parsing both 23/24 parsing.


resolves #113 