### PR TITLE
[exporter/license] license json metadata compatibility 24.05

### DIFF
--- a/exporter/license.go
+++ b/exporter/license.go
@@ -25,15 +25,8 @@ type LicenseMetric struct {
 
 type scontrolLicResponse struct {
 	Meta struct {
-		SlurmVersion struct {
-			Version struct {
-				Major int `json:"major"`
-				Micro int `json:"micro"`
-				Minor int `json:"minor"`
-			} `json:"version"`
-			Release string `json:"release"`
-		} `json:"Slurm"`
-	} `json:"meta"`
+		SlurmVersion SlurmVersion `json:"meta"`
+	}
 	Licenses []LicenseMetric `json:"licenses"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rivosinc/prometheus-slurm-exporter
 
-go 1.23
+go 1.23.1
 
 require (
 	github.com/prometheus/client_golang v1.20.5


### PR DESCRIPTION
Wrote a compatible metadata object, but forgot to apply it to the license exporter.

resolves #115 