### PR TITLE
[exporter] add server-based metrics filtering

### DIFF
--- a/exporter/main_test.go
+++ b/exporter/main_test.go
@@ -32,13 +32,13 @@ func TestMain(m *testing.M) {
 func TestPromServer(t *testing.T) {
 	assert := assert.New(t)
 	cliOpts := &CliOpts{
-		sinfo:  []string{"cat", "fixtures/sinfo_out.json"},
-		squeue: []string{"cat", "fixtures/squeue_out.json"},
+		sinfo:         []string{"cat", "fixtures/sinfo_out.json"},
+		squeue:        []string{"cat", "fixtures/squeue_out.json"},
+		excludeFilter: regexp.MustCompile(""),
 	}
 	config := &Config{
-		PollLimit:                 10,
-		cliOpts:                   cliOpts,
-		MetricsExcludeFilterRegex: regexp.MustCompile(""), // default: accept all metrics
+		PollLimit: 10,
+		cliOpts:   cliOpts,
 		TraceConf: &TraceConfig{
 			enabled: false,
 			sharedFetcher: &JobJsonFetcher{

--- a/exporter/main_test.go
+++ b/exporter/main_test.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"testing"
+
+	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"log/slog"
 )
 
 // global test setups
@@ -33,10 +35,10 @@ func TestPromServer(t *testing.T) {
 		sinfo:  []string{"cat", "fixtures/sinfo_out.json"},
 		squeue: []string{"cat", "fixtures/squeue_out.json"},
 	}
-
 	config := &Config{
-		PollLimit: 10,
-		cliOpts:   cliOpts,
+		PollLimit:                 10,
+		cliOpts:                   cliOpts,
+		MetricsExcludeFilterRegex: regexp.MustCompile(""), // default: accept all metrics
 		TraceConf: &TraceConfig{
 			enabled: false,
 			sharedFetcher: &JobJsonFetcher{

--- a/justfile
+++ b/justfile
@@ -41,6 +41,7 @@ devel: build
   -slurm.diag-cli "cat exporter/fixtures/sdiag.json" \
   -slurm.lic-cli "cat exporter/fixtures/license_out.json" \
   -slurm.sacctmgr-cli "cat exporter/fixtures/sacctmgr.txt"
+  # -metrics.filter-regex "slurm_.*"
 
 prod: build
   {{build_dir}}/slurm_exporter -slurm.cli-fallback -web.listen-address :9093

--- a/justfile
+++ b/justfile
@@ -41,7 +41,6 @@ devel: build
   -slurm.diag-cli "cat exporter/fixtures/sdiag.json" \
   -slurm.lic-cli "cat exporter/fixtures/license_out.json" \
   -slurm.sacctmgr-cli "cat exporter/fixtures/sacctmgr.txt"
-  # -metrics.filter-regex "slurm_.*"
 
 prod: build
   {{build_dir}}/slurm_exporter -slurm.cli-fallback -web.listen-address :9093

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	slurmDiagEnabled     = flag.Bool("slurm.collect-diags", false, "Collect daemon diagnostics stats from slurm")
 	slurmSacctEnabled    = flag.Bool("slurm.collect-limits", false, "Collect account and user limits from slurm")
 	slurmCliFallback     = flag.Bool("slurm.cli-fallback", true, "drop the --json arg and revert back to standard squeue for performance reasons")
-	metricsFilterRegex   = flag.String("slurm.exclude-metrics", "", "Regex pattern for metrics to exclude")
+	metricsFilterRegex   = flag.String("metrics.exclude", "", "Regex pattern for metrics to exclude")
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -32,27 +32,29 @@ var (
 	slurmDiagEnabled     = flag.Bool("slurm.collect-diags", false, "Collect daemon diagnostics stats from slurm")
 	slurmSacctEnabled    = flag.Bool("slurm.collect-limits", false, "Collect account and user limits from slurm")
 	slurmCliFallback     = flag.Bool("slurm.cli-fallback", true, "drop the --json arg and revert back to standard squeue for performance reasons")
+	metricsFilterRegex   = flag.String("metrics.filter-regex", "", "Regex pattern to filter metrics")
 )
 
 func main() {
 	flag.Parse()
 	cliFlags := exporter.CliFlags{
-		ListenAddress:        *listenAddress,
-		MetricsPath:          *metricsPath,
-		LogLevel:             *logLevel,
-		TraceEnabled:         *traceEnabled,
-		TracePath:            *tracePath,
-		SlurmPollLimit:       *slurmPollLimit,
-		SlurmSinfoOverride:   *slurmSinfoOverride,
-		SlurmSqueueOverride:  *slurmSqueueOverride,
-		SlurmLicenseOverride: *slurmLicenseOverride,
-		SlurmDiagOverride:    *slurmDiagOverride,
-		SlurmLicEnabled:      *slurmLicEnabled,
-		SlurmDiagEnabled:     *slurmDiagEnabled,
-		SacctEnabled:         *slurmSacctEnabled,
-		SlurmCliFallback:     *slurmCliFallback,
-		TraceRate:            *traceRate,
-		SlurmAcctOverride:    *slurmSaactOverride,
+		ListenAddress:             *listenAddress,
+		MetricsPath:               *metricsPath,
+		LogLevel:                  *logLevel,
+		TraceEnabled:              *traceEnabled,
+		TracePath:                 *tracePath,
+		SlurmPollLimit:            *slurmPollLimit,
+		SlurmSinfoOverride:        *slurmSinfoOverride,
+		SlurmSqueueOverride:       *slurmSqueueOverride,
+		SlurmLicenseOverride:      *slurmLicenseOverride,
+		SlurmDiagOverride:         *slurmDiagOverride,
+		SlurmLicEnabled:           *slurmLicEnabled,
+		SlurmDiagEnabled:          *slurmDiagEnabled,
+		SacctEnabled:              *slurmSacctEnabled,
+		SlurmCliFallback:          *slurmCliFallback,
+		TraceRate:                 *traceRate,
+		SlurmAcctOverride:         *slurmSaactOverride,
+		MetricsExcludeFilterRegex: *metricsFilterRegex,
 	}
 	config, err := exporter.NewConfig(&cliFlags)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	slurmDiagEnabled     = flag.Bool("slurm.collect-diags", false, "Collect daemon diagnostics stats from slurm")
 	slurmSacctEnabled    = flag.Bool("slurm.collect-limits", false, "Collect account and user limits from slurm")
 	slurmCliFallback     = flag.Bool("slurm.cli-fallback", true, "drop the --json arg and revert back to standard squeue for performance reasons")
-	metricsFilterRegex   = flag.String("metrics.filter-regex", "", "Regex pattern to filter metrics")
+	metricsFilterRegex   = flag.String("slurm.exclude-metrics", "", "Regex pattern for metrics to exclude")
 )
 
 func main() {


### PR DESCRIPTION
Introduce a regex exclude filter for metrics. The new option `-slurm.exclude-metrics` will **exclude** everything that matches it. I.e doing `-slurm.exclude-metrics "slurm_.*"` will exclude all slurm metrics. Works similarly to the node exporter's filter feature. Works by overriding prometheus' default gatherer interface and overlaying our regex on top of all gathered metrics.

side note: First time using github copilot to create a feature. Very impressed. 


resolves #117