### PR TITLE
[exporter/license] fix deficit reporting

### DIFF
--- a/exporter/license.go
+++ b/exporter/license.go
@@ -135,7 +135,7 @@ func (lc *LicCollector) Collect(ch chan<- prometheus.Metric) {
 		if lic.LastConsumed > 0 {
 			ch <- prometheus.MustNewConstMetric(lc.licLastConsumed, prometheus.GaugeValue, float64(lic.LastConsumed), lic.LicenseName)
 		}
-		if lic.Reserved > 0 {
+		if lic.LastDeficit > 0 {
 			ch <- prometheus.MustNewConstMetric(lc.licLastDeficit, prometheus.GaugeValue, float64(lic.LastDeficit), lic.LicenseName)
 		}
 	}

--- a/justfile
+++ b/justfile
@@ -29,6 +29,7 @@ build:
   mkdir {{build_dir}}
   CGO_ENABLED=0 go build -o {{build_dir}}/slurm_exporter .
 
+# run the exporter with fallback mode using the fixtures provided in exporter fixtures
 devel: build
   {{build_dir}}/slurm_exporter \
   -trace.enabled \


### PR DESCRIPTION
The last license reporting wouldn't report because it was erroneously not reporting if there were no reserved licenses 