### PR TITLE
[jobs] squeue based partition alt to alloc count from sinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ $ curl localhost:9092/metrics | grep "# HELP"
 # HELP slurm_user_state_total total jobs per state per user
 # HELP slurm_node_count_per_state nodes per state
 
+# Job summary metrics (squeue-based alternative to sinfo metrics, see issue #130)
+# HELP slurm_jobs_total_alloc_cpus total allocated cpus from squeue (alternative to sinfo-based metrics)
+# HELP slurm_jobs_total_alloc_mem total allocated memory from squeue (alternative to sinfo-based metrics)
+# HELP slurm_jobs_state_count count of jobs per state from squeue
+
 # Only available for -trace.enabled jobs
 # HELP slurm_proc_cpu_usage actual cpu usage collected from proc monitor
 # HELP slurm_proc_mem_usage proc mem usage

--- a/README.md
+++ b/README.md
@@ -124,10 +124,9 @@ $ curl localhost:9092/metrics | grep "# HELP"
 # HELP slurm_user_state_total total jobs per state per user
 # HELP slurm_node_count_per_state nodes per state
 
-# Job summary metrics (squeue-based alternative to sinfo metrics, see issue #130)
-# HELP slurm_jobs_total_alloc_cpus total allocated cpus from squeue (alternative to sinfo-based metrics)
-# HELP slurm_jobs_total_alloc_mem total allocated memory from squeue (alternative to sinfo-based metrics)
-# HELP slurm_jobs_state_count count of jobs per state from squeue
+# Partition job metrics (per state, similar to account metrics - see issue #130)
+# HELP slurm_partition_job_state_cpu_alloc alloc cpu consumed per partition per job state
+# HELP slurm_partition_job_state_mem_alloc alloc mem consumed per partition per job state
 
 # Only available for -trace.enabled jobs
 # HELP slurm_proc_cpu_usage actual cpu usage collected from proc monitor

--- a/exporter/jobs.go
+++ b/exporter/jobs.go
@@ -254,7 +254,9 @@ func parseAccountMetrics(jobs []JobMetric) map[string]*AccountMetric {
 }
 
 type PartitionJobMetric struct {
-	partitionState map[string]float64
+	stateJobCount map[string]float64
+	stateAllocCpu map[string]float64
+	stateAllocMem map[string]float64
 }
 
 func parsePartitionJobMetrics(jobs []JobMetric) map[string]*PartitionJobMetric {
@@ -263,11 +265,15 @@ func parsePartitionJobMetrics(jobs []JobMetric) map[string]*PartitionJobMetric {
 		metric, ok := partitionMetric[job.Partition]
 		if !ok {
 			metric = &PartitionJobMetric{
-				partitionState: make(map[string]float64),
+				stateJobCount: make(map[string]float64),
+				stateAllocCpu: make(map[string]float64),
+				stateAllocMem: make(map[string]float64),
 			}
 			partitionMetric[job.Partition] = metric
 		}
-		metric.partitionState[job.JobState]++
+		metric.stateJobCount[job.JobState]++
+		metric.stateAllocCpu[job.JobState] += job.JobResources.AllocCpus
+		metric.stateAllocMem[job.JobState] += totalAllocMem(&job.JobResources)
 	}
 	return partitionMetric
 }
@@ -320,26 +326,6 @@ func parseFeatureMetric(jobs []JobMetric) map[string]*FeatureJobMetric {
 	return featureMap
 }
 
-// JobSummaryMetric provides aggregate metrics from squeue data as an alternative
-// to sinfo-based metrics which can be inconsistent (see issue #130)
-type JobSummaryMetric struct {
-	TotalAllocCpus float64
-	TotalAllocMem  float64
-	StateJobCount  map[string]float64
-}
-
-func parseJobSummaryMetric(jobs []JobMetric) *JobSummaryMetric {
-	metric := &JobSummaryMetric{
-		StateJobCount: make(map[string]float64),
-	}
-	for _, job := range jobs {
-		metric.TotalAllocCpus += job.JobResources.AllocCpus
-		metric.TotalAllocMem += totalAllocMem(&job.JobResources)
-		metric.StateJobCount[job.JobState]++
-	}
-	return metric
-}
-
 type JobsCollector struct {
 	// collector state
 	fetcher      SlurmMetricFetcher[JobMetric]
@@ -350,8 +336,10 @@ type JobsCollector struct {
 	userJobStateTotal *prometheus.Desc
 	userJobMemAlloc   *prometheus.Desc
 	userJobCpuAlloc   *prometheus.Desc
-	// partition
-	partitionJobStateTotal *prometheus.Desc
+	// partition metrics
+	partitionJobStateTotal    *prometheus.Desc
+	partitionJobStateCpuAlloc *prometheus.Desc
+	partitionJobStateMemAlloc *prometheus.Desc
 	// account metrics
 	accountJobStateMemAlloc *prometheus.Desc
 	accountJobStateCpuAlloc *prometheus.Desc
@@ -362,10 +350,6 @@ type JobsCollector struct {
 	featureJobTotal    *prometheus.Desc
 	// reason metrics
 	pendingReasonTotal *prometheus.Desc
-	// job summary metrics
-	jobsTotalAllocCpus *prometheus.Desc
-	jobsTotalAllocMem  *prometheus.Desc
-	jobsStateCount     *prometheus.Desc
 	// exporter metrics
 	jobScrapeDuration *prometheus.Desc
 	jobScrapeError    prometheus.Counter
@@ -382,24 +366,22 @@ func NewJobsController(config *Config) *JobsCollector {
 		fetcher:  fetcher,
 		fallback: cliOpts.fallback,
 		// individual job metrics
-		jobAllocCpus:            prometheus.NewDesc("slurm_job_alloc_cpus", "amount of cpus allocated per job", []string{"jobid"}, nil),
-		jobAllocMem:             prometheus.NewDesc("slurm_job_alloc_mem", "amount of mem allocated per job", []string{"jobid"}, nil),
-		userJobStateTotal:       prometheus.NewDesc("slurm_user_state_total", "total jobs per state per user", []string{"username", "state"}, nil),
-		userJobMemAlloc:         prometheus.NewDesc("slurm_user_mem_alloc", "total mem alloc per user", []string{"username", "state"}, nil),
-		userJobCpuAlloc:         prometheus.NewDesc("slurm_user_cpu_alloc", "total cpu alloc per user", []string{"username", "state"}, nil),
-		partitionJobStateTotal:  prometheus.NewDesc("slurm_partition_job_state_total", "total jobs per partition per state", []string{"partition", "state"}, nil),
-		accountJobStateMemAlloc: prometheus.NewDesc("slurm_account_job_state_mem_alloc", "alloc mem consumed per account per job state", []string{"account", "state"}, nil),
-		accountJobStateCpuAlloc: prometheus.NewDesc("slurm_account_job_state_cpu_alloc", "alloc cpu consumed per account per job state", []string{"account", "state"}, nil),
-		accountJobStateTotal:    prometheus.NewDesc("slurm_account_job_state_total", "total jobs per account per job state", []string{"account", "state"}, nil),
-		featureJobMemAlloc:      prometheus.NewDesc("slurm_feature_mem_alloc", "alloc mem consumed per feature", []string{"feature"}, nil),
-		featureJobCpuAlloc:      prometheus.NewDesc("slurm_feature_cpu_alloc", "alloc cpu consumed per feature", []string{"feature"}, nil),
-		featureJobTotal:         prometheus.NewDesc("slurm_feature_total", "alloc cpu consumed per feature", []string{"feature"}, nil),
-		pendingReasonTotal:      prometheus.NewDesc("slurm_pending_reason_total", "count of the reason jobs are pending", []string{"reason"}, nil),
-		// job summary metrics (squeue-based alternative to sinfo metrics, see issue #130)
-		jobsTotalAllocCpus: prometheus.NewDesc("slurm_jobs_total_alloc_cpus", "total allocated cpus from squeue (alternative to sinfo-based metrics)", nil, nil),
-		jobsTotalAllocMem:  prometheus.NewDesc("slurm_jobs_total_alloc_mem", "total allocated memory from squeue (alternative to sinfo-based metrics)", nil, nil),
-		jobsStateCount:     prometheus.NewDesc("slurm_jobs_state_count", "count of jobs per state from squeue", []string{"state"}, nil),
-		jobScrapeDuration:  prometheus.NewDesc("slurm_job_scrape_duration", fmt.Sprintf("how long the cmd %v took (ms)", cliOpts.squeue), nil, nil),
+		jobAllocCpus:              prometheus.NewDesc("slurm_job_alloc_cpus", "amount of cpus allocated per job", []string{"jobid"}, nil),
+		jobAllocMem:               prometheus.NewDesc("slurm_job_alloc_mem", "amount of mem allocated per job", []string{"jobid"}, nil),
+		userJobStateTotal:         prometheus.NewDesc("slurm_user_state_total", "total jobs per state per user", []string{"username", "state"}, nil),
+		userJobMemAlloc:           prometheus.NewDesc("slurm_user_mem_alloc", "total mem alloc per user", []string{"username", "state"}, nil),
+		userJobCpuAlloc:           prometheus.NewDesc("slurm_user_cpu_alloc", "total cpu alloc per user", []string{"username", "state"}, nil),
+		partitionJobStateTotal:    prometheus.NewDesc("slurm_partition_job_state_total", "total jobs per partition per state", []string{"partition", "state"}, nil),
+		partitionJobStateCpuAlloc: prometheus.NewDesc("slurm_partition_job_state_cpu_alloc", "alloc cpu consumed per partition per job state", []string{"partition", "state"}, nil),
+		partitionJobStateMemAlloc: prometheus.NewDesc("slurm_partition_job_state_mem_alloc", "alloc mem consumed per partition per job state", []string{"partition", "state"}, nil),
+		accountJobStateMemAlloc:   prometheus.NewDesc("slurm_account_job_state_mem_alloc", "alloc mem consumed per account per job state", []string{"account", "state"}, nil),
+		accountJobStateCpuAlloc:   prometheus.NewDesc("slurm_account_job_state_cpu_alloc", "alloc cpu consumed per account per job state", []string{"account", "state"}, nil),
+		accountJobStateTotal:      prometheus.NewDesc("slurm_account_job_state_total", "total jobs per account per job state", []string{"account", "state"}, nil),
+		featureJobMemAlloc:        prometheus.NewDesc("slurm_feature_mem_alloc", "alloc mem consumed per feature", []string{"feature"}, nil),
+		featureJobCpuAlloc:        prometheus.NewDesc("slurm_feature_cpu_alloc", "alloc cpu consumed per feature", []string{"feature"}, nil),
+		featureJobTotal:           prometheus.NewDesc("slurm_feature_total", "alloc cpu consumed per feature", []string{"feature"}, nil),
+		pendingReasonTotal:        prometheus.NewDesc("slurm_pending_reason_total", "count of the reason jobs are pending", []string{"reason"}, nil),
+		jobScrapeDuration:         prometheus.NewDesc("slurm_job_scrape_duration", fmt.Sprintf("how long the cmd %v took (ms)", cliOpts.squeue), nil, nil),
 		jobScrapeError: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "slurm_job_scrape_error",
 			Help: "slurm job scrape error",
@@ -414,6 +396,8 @@ func (jc *JobsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- jc.userJobMemAlloc
 	ch <- jc.userJobCpuAlloc
 	ch <- jc.partitionJobStateTotal
+	ch <- jc.partitionJobStateCpuAlloc
+	ch <- jc.partitionJobStateMemAlloc
 	ch <- jc.accountJobStateMemAlloc
 	ch <- jc.accountJobStateCpuAlloc
 	ch <- jc.accountJobStateTotal
@@ -421,9 +405,6 @@ func (jc *JobsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- jc.featureJobCpuAlloc
 	ch <- jc.featureJobTotal
 	ch <- jc.pendingReasonTotal
-	ch <- jc.jobsTotalAllocCpus
-	ch <- jc.jobsTotalAllocMem
-	ch <- jc.jobsStateCount
 	ch <- jc.jobScrapeDuration
 	ch <- jc.jobScrapeError.Desc()
 }
@@ -474,9 +455,9 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	partitionJobMetrics := parsePartitionJobMetrics(jobMetrics)
 	for partition, stateTotals := range partitionJobMetrics {
-		for state, totalJobs := range stateTotals.partitionState {
-			ch <- prometheus.MustNewConstMetric(jc.partitionJobStateTotal, prometheus.GaugeValue, totalJobs, partition, state)
-		}
+		emitNonZeroStateConstGuage(jc.partitionJobStateTotal, stateTotals.stateJobCount, partition)
+		emitNonZeroStateConstGuage(jc.partitionJobStateCpuAlloc, stateTotals.stateAllocCpu, partition)
+		emitNonZeroStateConstGuage(jc.partitionJobStateMemAlloc, stateTotals.stateAllocMem, partition)
 	}
 
 	featureJobMetric := parseFeatureMetric(jobMetrics)
@@ -495,12 +476,5 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 	stateReasonMetric := parseStateReasonMetric(jobMetrics)
 	for pendingReason, pendingCount := range stateReasonMetric.pendingStateCount {
 		ch <- prometheus.MustNewConstMetric(jc.pendingReasonTotal, prometheus.GaugeValue, pendingCount, pendingReason)
-	}
-
-	jobSummaryMetric := parseJobSummaryMetric(jobMetrics)
-	ch <- prometheus.MustNewConstMetric(jc.jobsTotalAllocCpus, prometheus.GaugeValue, jobSummaryMetric.TotalAllocCpus)
-	ch <- prometheus.MustNewConstMetric(jc.jobsTotalAllocMem, prometheus.GaugeValue, jobSummaryMetric.TotalAllocMem)
-	for state, count := range jobSummaryMetric.StateJobCount {
-		ch <- prometheus.MustNewConstMetric(jc.jobsStateCount, prometheus.GaugeValue, count, state)
 	}
 }

--- a/exporter/jobs.go
+++ b/exporter/jobs.go
@@ -320,6 +320,26 @@ func parseFeatureMetric(jobs []JobMetric) map[string]*FeatureJobMetric {
 	return featureMap
 }
 
+// JobSummaryMetric provides aggregate metrics from squeue data as an alternative
+// to sinfo-based metrics which can be inconsistent (see issue #130)
+type JobSummaryMetric struct {
+	TotalAllocCpus float64
+	TotalAllocMem  float64
+	StateJobCount  map[string]float64
+}
+
+func parseJobSummaryMetric(jobs []JobMetric) *JobSummaryMetric {
+	metric := &JobSummaryMetric{
+		StateJobCount: make(map[string]float64),
+	}
+	for _, job := range jobs {
+		metric.TotalAllocCpus += job.JobResources.AllocCpus
+		metric.TotalAllocMem += totalAllocMem(&job.JobResources)
+		metric.StateJobCount[job.JobState]++
+	}
+	return metric
+}
+
 type JobsCollector struct {
 	// collector state
 	fetcher      SlurmMetricFetcher[JobMetric]
@@ -342,6 +362,10 @@ type JobsCollector struct {
 	featureJobTotal    *prometheus.Desc
 	// reason metrics
 	pendingReasonTotal *prometheus.Desc
+	// job summary metrics
+	jobsTotalAllocCpus *prometheus.Desc
+	jobsTotalAllocMem  *prometheus.Desc
+	jobsStateCount     *prometheus.Desc
 	// exporter metrics
 	jobScrapeDuration *prometheus.Desc
 	jobScrapeError    prometheus.Counter
@@ -371,7 +395,11 @@ func NewJobsController(config *Config) *JobsCollector {
 		featureJobCpuAlloc:      prometheus.NewDesc("slurm_feature_cpu_alloc", "alloc cpu consumed per feature", []string{"feature"}, nil),
 		featureJobTotal:         prometheus.NewDesc("slurm_feature_total", "alloc cpu consumed per feature", []string{"feature"}, nil),
 		pendingReasonTotal:      prometheus.NewDesc("slurm_pending_reason_total", "count of the reason jobs are pending", []string{"reason"}, nil),
-		jobScrapeDuration:       prometheus.NewDesc("slurm_job_scrape_duration", fmt.Sprintf("how long the cmd %v took (ms)", cliOpts.squeue), nil, nil),
+		// job summary metrics (squeue-based alternative to sinfo metrics, see issue #130)
+		jobsTotalAllocCpus: prometheus.NewDesc("slurm_jobs_total_alloc_cpus", "total allocated cpus from squeue (alternative to sinfo-based metrics)", nil, nil),
+		jobsTotalAllocMem:  prometheus.NewDesc("slurm_jobs_total_alloc_mem", "total allocated memory from squeue (alternative to sinfo-based metrics)", nil, nil),
+		jobsStateCount:     prometheus.NewDesc("slurm_jobs_state_count", "count of jobs per state from squeue", []string{"state"}, nil),
+		jobScrapeDuration:  prometheus.NewDesc("slurm_job_scrape_duration", fmt.Sprintf("how long the cmd %v took (ms)", cliOpts.squeue), nil, nil),
 		jobScrapeError: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "slurm_job_scrape_error",
 			Help: "slurm job scrape error",
@@ -393,6 +421,9 @@ func (jc *JobsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- jc.featureJobCpuAlloc
 	ch <- jc.featureJobTotal
 	ch <- jc.pendingReasonTotal
+	ch <- jc.jobsTotalAllocCpus
+	ch <- jc.jobsTotalAllocMem
+	ch <- jc.jobsStateCount
 	ch <- jc.jobScrapeDuration
 	ch <- jc.jobScrapeError.Desc()
 }
@@ -464,5 +495,12 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 	stateReasonMetric := parseStateReasonMetric(jobMetrics)
 	for pendingReason, pendingCount := range stateReasonMetric.pendingStateCount {
 		ch <- prometheus.MustNewConstMetric(jc.pendingReasonTotal, prometheus.GaugeValue, pendingCount, pendingReason)
+	}
+
+	jobSummaryMetric := parseJobSummaryMetric(jobMetrics)
+	ch <- prometheus.MustNewConstMetric(jc.jobsTotalAllocCpus, prometheus.GaugeValue, jobSummaryMetric.TotalAllocCpus)
+	ch <- prometheus.MustNewConstMetric(jc.jobsTotalAllocMem, prometheus.GaugeValue, jobSummaryMetric.TotalAllocMem)
+	for state, count := range jobSummaryMetric.StateJobCount {
+		ch <- prometheus.MustNewConstMetric(jc.jobsStateCount, prometheus.GaugeValue, count, state)
 	}
 }

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -184,7 +184,10 @@ func TestParsePartitionJobMetrics(t *testing.T) {
 	assert.Nil(err)
 
 	partitionJobMetrics := parsePartitionJobMetrics(jms)
-	assert.Equal(float64(1), partitionJobMetrics["hw-l"].partitionState["RUNNING"])
+	assert.Equal(float64(1), partitionJobMetrics["hw-l"].stateJobCount["RUNNING"])
+	// verify CPU and memory allocation per state are tracked
+	assert.NotZero(partitionJobMetrics["hw-l"].stateAllocCpu["RUNNING"])
+	assert.NotZero(partitionJobMetrics["hw-l"].stateAllocMem["RUNNING"])
 }
 
 func TestParsePartMetrics(t *testing.T) {
@@ -373,28 +376,7 @@ func TestParseStateReasonMetric_Json(t *testing.T) {
 	assert.Equal(m.pendingStateCount["Dependency"], 1.)
 }
 
-func TestParseJobSummaryMetric_Json(t *testing.T) {
-	assert := assert.New(t)
-	scraper := &MockScraper{fixture: "fixtures/squeue_out.json"}
-	JsonFetcher := &JobJsonFetcher{
-		scraper:    scraper,
-		cache:      NewAtomicThrottledCache[JobMetric](0),
-		errCounter: prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"}),
-	}
-	jobMetrics, err := JsonFetcher.FetchMetrics()
-	assert.NotEmpty(jobMetrics)
-	assert.NoError(err)
-	m := parseJobSummaryMetric(jobMetrics)
-	// verify aggregate totals are computed
-	assert.NotZero(m.TotalAllocCpus)
-	assert.NotZero(m.TotalAllocMem)
-	assert.NotEmpty(m.StateJobCount)
-	// verify specific state counts
-	assert.Equal(1., m.StateJobCount["RUNNING"])
-	assert.Equal(1., m.StateJobCount["PENDING"])
-}
-
-func TestParseJobSummaryMetric_Fallback(t *testing.T) {
+func TestParsePartitionJobMetrics_Fallback(t *testing.T) {
 	assert := assert.New(t)
 	scraper := &MockScraper{fixture: "fixtures/squeue_fallback.txt"}
 	cliFallbackFetcher := &JobCliFallbackFetcher{
@@ -403,15 +385,37 @@ func TestParseJobSummaryMetric_Fallback(t *testing.T) {
 		errCounter: prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"}),
 	}
 	jobMetrics, err := cliFallbackFetcher.FetchMetrics()
-	assert.NotEmpty(jobMetrics)
 	assert.NoError(err)
-	m := parseJobSummaryMetric(jobMetrics)
-	// verify aggregate totals are computed
-	assert.NotEmpty(m.StateJobCount)
-	// verify state counts match expected job states in fallback fixture
-	totalJobs := 0.
-	for _, count := range m.StateJobCount {
-		totalJobs += count
-	}
-	assert.Equal(float64(len(jobMetrics)), totalJobs)
+	m := parsePartitionJobMetrics(jobMetrics)
+	assert.Len(m, 3) // hw-h, hw-l, magma
+
+	// Test "hw-h" partition:
+	hwH := m["hw-h"]
+	assert.NotNil(hwH)
+	assert.Equal(1., hwH.stateJobCount["RUNNING"])
+	assert.Equal(1., hwH.stateAllocCpu["RUNNING"])
+	assert.Equal(128e9, hwH.stateAllocMem["RUNNING"])
+	assert.Equal(3., hwH.stateJobCount["PENDING"])
+	assert.Equal(3., hwH.stateAllocCpu["PENDING"])
+	assert.Equal(3*40000e6, hwH.stateAllocMem["PENDING"]) // 3 jobs * 40000M
+
+	// Test "hw-l" partition:
+	hwL := m["hw-l"]
+	assert.NotNil(hwL)
+	assert.Equal(1., hwL.stateJobCount["RUNNING"])
+	assert.Equal(1., hwL.stateAllocCpu["RUNNING"])
+	assert.Equal(62.5e9, hwL.stateAllocMem["RUNNING"])
+	assert.Zero(hwL.stateJobCount["PENDING"])
+	assert.Zero(hwL.stateAllocCpu["PENDING"])
+	assert.Zero(hwL.stateAllocMem["PENDING"])
+
+	// Test "magma" partition:
+	magma := m["magma"]
+	assert.NotNil(magma)
+	assert.Zero(magma.stateJobCount["RUNNING"])
+	assert.Zero(magma.stateAllocCpu["RUNNING"])
+	assert.Zero(magma.stateAllocMem["RUNNING"])
+	assert.Equal(1., magma.stateJobCount["PENDING"])
+	assert.Equal(24., magma.stateAllocCpu["PENDING"])
+	assert.Equal(118e9, magma.stateAllocMem["PENDING"])
 }

--- a/exporter/jobs_test.go
+++ b/exporter/jobs_test.go
@@ -372,3 +372,46 @@ func TestParseStateReasonMetric_Json(t *testing.T) {
 	assert.NotEmpty(m.pendingStateCount)
 	assert.Equal(m.pendingStateCount["Dependency"], 1.)
 }
+
+func TestParseJobSummaryMetric_Json(t *testing.T) {
+	assert := assert.New(t)
+	scraper := &MockScraper{fixture: "fixtures/squeue_out.json"}
+	JsonFetcher := &JobJsonFetcher{
+		scraper:    scraper,
+		cache:      NewAtomicThrottledCache[JobMetric](0),
+		errCounter: prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"}),
+	}
+	jobMetrics, err := JsonFetcher.FetchMetrics()
+	assert.NotEmpty(jobMetrics)
+	assert.NoError(err)
+	m := parseJobSummaryMetric(jobMetrics)
+	// verify aggregate totals are computed
+	assert.NotZero(m.TotalAllocCpus)
+	assert.NotZero(m.TotalAllocMem)
+	assert.NotEmpty(m.StateJobCount)
+	// verify specific state counts
+	assert.Equal(1., m.StateJobCount["RUNNING"])
+	assert.Equal(1., m.StateJobCount["PENDING"])
+}
+
+func TestParseJobSummaryMetric_Fallback(t *testing.T) {
+	assert := assert.New(t)
+	scraper := &MockScraper{fixture: "fixtures/squeue_fallback.txt"}
+	cliFallbackFetcher := &JobCliFallbackFetcher{
+		scraper:    scraper,
+		cache:      NewAtomicThrottledCache[JobMetric](0),
+		errCounter: prometheus.NewCounter(prometheus.CounterOpts{Name: "errors"}),
+	}
+	jobMetrics, err := cliFallbackFetcher.FetchMetrics()
+	assert.NotEmpty(jobMetrics)
+	assert.NoError(err)
+	m := parseJobSummaryMetric(jobMetrics)
+	// verify aggregate totals are computed
+	assert.NotEmpty(m.StateJobCount)
+	// verify state counts match expected job states in fallback fixture
+	totalJobs := 0.
+	for _, count := range m.StateJobCount {
+		totalJobs += count
+	}
+	assert.Equal(float64(len(jobMetrics)), totalJobs)
+}


### PR DESCRIPTION
sinfo seems to sometimes dump incorrect alloc counts (maybe due to gpu accounting ???). Until we can actually get to the bottom of that, we give users the alternative to poll metrics from a user queueing perspective instead of a node level alloc perspective. Arguably, this should be switched to the default as this is probably what people are referring to when they ask: _"how many cpu's are allocated (requested by users) on my cluster?"_.

resolves #130 